### PR TITLE
Update steps for generating markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A repository to generate documentation from doc strings
 
 ### Initial setup
 
-```
+```bash
 python -m venv venv
 
 source venv/bin/activate
@@ -18,7 +18,12 @@ source venv/bin/activate
 
 pip install -r requirements.txt
 git submodule update --init --recursive
-git submodule update --recursive --remote
+
+git submodule foreach -q --recursive 'git checkout $(git config -f $toplevel/.gitmodules submodule.$name.branch || echo main)'
+
+git pull "$@" &&
+  git submodule sync --recursive &&
+  git submodule update --init --recursive
 ```
 
 ### Generate markdowns
@@ -38,6 +43,7 @@ python generate_markdowns.py -l ocean.py aquarius provider ocean-subgraph
 Generate the markdowns and push the changes to `main` branch or raise a PR and merge changes to `main`.
 
 Refresh the [Ocean Procotol docs](https://github.com/oceanprotocol/docs) deployment by creating a new PR with a dummy commit.
+
 1. Clone `docs` repository and create a new branch.
 2. `git commit --allow-empty -m "Trigger rebuild"`.
 3. Push the changes.


### PR DESCRIPTION
Avoid detaching HEAD while cloning. The updated steps will help to checkout submodules with `main` as default branch.

Changes proposed in this PR:

- Updated readme
