### PR TITLE
Issue497 update oceanpy markdowns v0.8.1

### DIFF
--- a/markdowns/ocean-py/README.md
+++ b/markdowns/ocean-py/README.md
@@ -3,8 +3,8 @@ title: README.md
 slug: README.md
 app: ocean.py
 module: README
-source: https://github.com/oceanprotocol/ocean.py/blob/main/README.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/README.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/README.md
+++ b/markdowns/ocean-py/README.md
@@ -3,7 +3,7 @@ title: README.md
 slug: README.md
 app: ocean.py
 module: README
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/README.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/README.md
 version: 0.8.1
 ---
 <!--
@@ -49,6 +49,7 @@ This is in beta state and you can expect running into problems. If you run into 
 - [🏄 Quickstart](#-quickstart)
   - [Simple Flow](#simple-flow)
   - [Marketplace Flow](#marketplace-flow)
+  - [Compute-to-Data Flow](#compute-to-data-flow)
   - [Learn more](#learn-more)
 - [🦑 Development](#-development)
 - [🏛 License](#-license)
@@ -60,6 +61,9 @@ This is in beta state and you can expect running into problems. If you run into 
 pip install wheel
 pip install ocean-lib
 ```
+⚠️ For Mac users, if you encounter an issue with "Unsupported Architecture", see [this issue](https://github.com/oceanprotocol/ocean.py/issues/486) for an explanation and run the installation command with ARCHFLAGS set, like so:
+
+`ARCHFLAGS="-arch x86_64" pip install ocean-lib`
 
 ## 🏄 Quickstart
 
@@ -71,9 +75,15 @@ This stripped-down flow shows the essence of Ocean: simply creating a datatoken.
 
 ### Marketplace flow
 
-This batteries-included flow includes metadata and datatoken pool.
+In this flow, a data asset is posted for sale in a marketplace, and purchased. It includes metadata and a datatoken pool.
 
 [Go to marketplace flow](READMEs/marketplace-flow.md)
+
+### Compute-to-Data flow
+
+This flow uses Ocean Compute-to-Data (c2d) to compute results from a dataset that never leaves the premises.
+
+[Go to c2d flow](READMEs/c2d-flow.md)
 
 ### Learn more
 

--- a/markdowns/ocean-py/READMEs/ALG_ddo.md
+++ b/markdowns/ocean-py/READMEs/ALG_ddo.md
@@ -1,0 +1,78 @@
+---
+title: ALG_ddo.md
+slug: READMEs/ALG_ddo.md
+app: ocean.py
+module: READMEs.ALG_ddo
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/ALG_ddo.md
+version: 0.8.1
+---
+(HACK to help debugging. Remove later)
+
+In Python console:
+```python
+pprint.PrettyPrinter(indent=2).pprint(ALG_ddo.as_dictionary())
+
+{
+  '@context': 'https://w3id.org/did/v1',
+  'authentication': [
+    {
+      'publicKey': 'did:op:beD519EF79eE3b06b94751dFC8ce62587b8de6Cf',
+      'type': 'RsaSignatureAuthentication2018'
+    }],
+    
+  'created': '2021-08-24T11:57:45Z',
+  'dataToken': '0xbeD519EF79eE3b06b94751dFC8ce62587b8de6Cf',
+  'id': 'did:op:beD519EF79eE3b06b94751dFC8ce62587b8de6Cf',
+  
+  'proof': {
+    'checksum': {
+      '0': '09db9193f00de71305d5100d3a2c7d2e08a2a81e958fefe6defb7391ed46fca8',
+      '3': '96f72f4c84d8799e3cc2017e202c4cabe387efb4f43a6c07d2a16ffad7f70bdf'
+    },
+    'created': '2021-08-24T11:57:45Z',
+    'creator': '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260',
+    'signatureValue': '0x8d4b0c2ae7485e67bb43c6e32a4d4058861807909b9064c242f24c2bc288c6b378cd8fd585302c90cccf449e3cbda3eff58850f4d240680e03f8ba68414180d61c',
+    'type': 'DDOIntegritySignature'
+  },
+  'publicKey': [
+    {
+      'id': 'did:op:beD519EF79eE3b06b94751dFC8ce62587b8de6Cf',
+      'owner': '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260',
+      'type': 'EthereumECDSAKey'
+    }],
+    
+  'service': [
+    {
+      'attributes': {
+        'encryptedFiles': '0x04939dd7...7ab9da', #large blob
+        'main': { 'author': 'Trent',
+        'dateCreated': '2020-01-28T10:55:11Z',
+        'files': [
+	  {
+	    'contentType': 'text/text',
+            'index': 0
+	  }],
+        'license': 'CC0',
+        'name': 'gpr',
+        'type': 'algorithm'
+      } },
+      'index': 0,
+      'serviceEndpoint': 'http://localhost:5000/api/v1/aquarius/assets/ddo/did:op:beD519EF79eE3b06b94751dFC8ce62587b8de6Cf',
+      'type': 'metadata'
+    },
+    
+    {
+      'attributes': {
+        'main': {
+	  'cost': 1.0,
+          'creator': '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260',
+          'datePublished': '2020-01-28T10:55:11Z',
+          'name': 'ALG_dataAssetAccessServiceAgreement',
+          'timeout': 86400
+      } },
+      'index': 3,
+      'serviceEndpoint': 'http://localhost:8030',
+      'type': 'access'
+  }]
+}
+```

--- a/markdowns/ocean-py/READMEs/DATA_ddo.md
+++ b/markdowns/ocean-py/READMEs/DATA_ddo.md
@@ -1,0 +1,80 @@
+---
+title: DATA_ddo.md
+slug: READMEs/DATA_ddo.md
+app: ocean.py
+module: READMEs.DATA_ddo
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/DATA_ddo.md
+version: 0.8.1
+---
+(HACK to help debugging. Remove later)
+
+In Python console:
+```python
+pprint.PrettyPrinter(indent=2).pprint(DATA_ddo.as_dictionary())
+
+{
+  'id': 'did:op:4568CA67353c0db9eA07Fdf85Dc051468cF7397f',
+  'dataToken': '0x4568CA67353c0db9eA07Fdf85Dc051468cF7397f',
+  'publicKey': [
+    {
+      'id': 'did:op:4568CA67353c0db9eA07Fdf85Dc051468cF7397f',
+      'owner': '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260',
+      'type': 'EthereumECDSAKey'
+    }],
+  
+  'service': [
+    {
+      'type': 'metadata',
+      'index': 0,
+      'serviceEndpoint': 'http://localhost:5000/api/v1/aquarius/assets/ddo/did:op:4568CA67353c0db9eA07Fdf85Dc051468cF7397f',
+      'attributes': {
+        'encryptedFiles': '0x049031...47d0gsgdsasdoidsoimaoimw9494214', #large blob
+        'main': {
+          'type': 'dataset'
+          'files': [
+	    {
+              'index': 0
+	      'contentType': 'text/text',
+	    }],
+          'license': 'CC0',
+          'name': 'branin',
+	  'author': 'Trent',
+          'dateCreated': '2019-12-28T10:55:11Z'
+      } }
+    },
+
+    {
+      'type': 'access'
+      'index': 3,
+      'serviceEndpoint': 'http://localhost:8030',
+      'attributes': {
+        'main': {
+          'creator': '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260',
+          'datePublished': '2019-12-28T10:55:11Z',
+          'name': 'DATA_dataAssetAccessServiceAgreement',
+          'timeout': 86400,
+	  'cost': 1.0
+    } } }
+  ],
+
+  '@context': 'https://w3id.org/did/v1',
+  'created': '2021-08-24T11:01:32Z',
+  'authentication': [
+    {
+      'publicKey': 'did:op:4568CA67353c0db9eA07Fdf85Dc051468cF7397f',
+      'type': 'RsaSignatureAuthentication2018'
+     } ],
+  'proof': {
+    'checksum':
+    {
+      '0': '667a2fd0ec238a4134a2b47b76c0e9359f5e66e55e861fe81ecddf23bfab1dcf',
+      '3': '5188714e14e4aafbd56101f7406a96b912f250e2d75fdd7f3c00801cd64e71f8'
+    },
+    'created': '2021-08-24T11:01:32Z',
+    'creator': '0xe2DD09d719Da89e5a3D0F2549c7E24566e947260',
+    'signatureValue': '0x17d91de3829..',
+    'type': 'DDOIntegritySignature'
+    }
+  }
+}
+```

--- a/markdowns/ocean-py/READMEs/c2d-flow.md
+++ b/markdowns/ocean-py/READMEs/c2d-flow.md
@@ -1,0 +1,388 @@
+---
+title: c2d-flow.md
+slug: READMEs/c2d-flow.md
+app: ocean.py
+module: READMEs.c2d-flow
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/c2d-flow.md
+version: 0.8.1
+---
+<!--
+Copyright 2021 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Quickstart: Compute-to-Data (C2D) Flow
+
+This quickstart describes a C2D flow.
+
+Here are the steps:
+
+1. Setup
+2. Alice publishes data asset
+3. Alice publishes algorithm
+4. Alice allows the algorithm for C2D for that data asset
+5. Bob acquires datatokens for data and algorithm
+6. Bob starts a compute job
+7. Bob monitors logs / algorithm output
+
+This c2d flow example features a simple algorithm from the field of ML. Ocean c2d is not limited to ML datasets and algorithms, but it is one of the most common use cases. For a simple image processing example, you can check out [ocean-lena](https://github.com/calina-c/ocean-lena/blob/main/c2d-flow.md).
+
+Let's go through each step.
+
+## 1. Setup
+
+### Prerequisites
+
+-   Linux/MacOS
+-   [Docker](https://docs.docker.com/engine/install/), [Docker Compose](https://docs.docker.com/compose/install/), [allowing non-root users](https://www.thegeekdiary.com/run-docker-as-a-non-root-user/)
+-   Python 3.8.5+
+
+### Run barge services
+
+Ocean `barge` runs ganache (local blockchain), Provider (data service), and Aquarius (metadata cache).
+
+In a new console:
+
+```console
+#grab repo
+git clone https://github.com/oceanprotocol/barge
+cd barge
+
+#clean up old containers (to be sure)
+docker system prune -a --volumes
+
+# make sure to use the dev version of the operator service URL, to match the barge provider
+export OPERATOR_SERVICE_URL=https://c2d-dev.operator.oceanprotocol.com/
+
+#run barge: start ganache, Provider, Aquarius; deploy contracts; update ~/.ocean
+./start_ocean.sh  --with-provider2
+```
+
+### Install the library
+
+In a new console that we'll call the work console (as we'll use it later):
+
+```console
+#Initialize virtual environment and activate it.
+python -m venv venv
+source venv/bin/activate
+
+#Install the ocean.py library. Install wheel first to avoid errors.
+pip install wheel
+pip install ocean-lib
+```
+
+This example uses c2d to create a regression model. In order to visualise it or manipulate it, you also need some dependencies:
+
+```console
+pip install numpy
+pip install matplotlib
+```
+
+### Create config file
+
+In the work console:
+```console
+#Create config.ini file and fill it with configuration info
+echo """
+[eth-network]
+network = http://127.0.0.1:8545
+address.file = ~/.ocean/ocean-contracts/artifacts/address.json
+
+[resources]
+metadata_cache_uri = http://localhost:5000
+provider.url = http://localhost:8030
+provider.address = 0x00bd138abd70e2f00903268f3db08f2d25677c9e
+
+downloads.path = consume-downloads
+""" > config.ini
+```
+
+### Set envvars
+
+In the work console:
+```console
+#set private keys of two accounts
+export TEST_PRIVATE_KEY1=0x5d75837394b078ce97bc289fa8d75e21000573520bfa7784a9d28ccaae602bf8
+export TEST_PRIVATE_KEY2=0xef4b441145c1d0f3b4bc6d61d29f5c6e502359481152f869247c7a4244d45209
+```
+
+### Config in Python
+
+In the work console:
+```console
+python
+```
+
+For the following steps, we use the Python console. Keep it open between steps.
+
+In the Python console:
+```python
+#create ocean instance
+from ocean_lib.config import Config
+from ocean_lib.ocean.ocean import Ocean
+config = Config('config.ini')
+ocean = Ocean(config)
+
+print(f"config.network_url = '{config.network_url}'")
+print(f"config.metadata_cache_uri = '{config.metadata_cache_uri}'")
+print(f"config.provider_url = '{config.provider_url}'")
+
+# Create Alice's wallet
+import os
+from ocean_lib.web3_internal.wallet import Wallet
+alice_wallet = Wallet(ocean.web3, os.getenv('TEST_PRIVATE_KEY1'), config.block_confirmations)
+print(f"alice_wallet.address = '{alice_wallet.address}'")
+```
+
+## 2. Alice publishes data asset
+
+In the same Python console:
+```python
+# Publish DATA datatoken, mint tokens
+from ocean_lib.web3_internal.currency import to_wei
+
+DATA_datatoken = ocean.create_data_token('DATA1', 'DATA1', alice_wallet, blob=ocean.config.metadata_cache_uri)
+DATA_datatoken.mint(alice_wallet.address, to_wei(100), alice_wallet)
+print(f"DATA_datatoken.address = '{DATA_datatoken.address}'")
+
+# Specify metadata & service attributes for Branin test dataset.
+# It's specified using _local_ DDO metadata format; Aquarius will convert it to remote
+# by removing `url` and adding `encryptedFiles` field.
+DATA_metadata = {
+    "main": {
+        "type": "dataset",
+        "files": [
+	  {
+	    "url": "https://raw.githubusercontent.com/trentmc/branin/main/branin.arff",
+	    "index": 0,
+	    "contentType": "text/text"
+	  }
+	],
+	"name": "branin", "author": "Trent", "license": "CC0",
+	"dateCreated": "2019-12-28T10:55:11Z"
+    }
+}
+DATA_service_attributes = {
+    "main": {
+        "name": "DATA_dataAssetAccessServiceAgreement",
+        "creator": alice_wallet.address,
+        "timeout": 3600 * 24,
+        "datePublished": "2019-12-28T10:55:11Z",
+        "cost": 1.0, # <don't change, this is obsolete>
+        }
+    }
+
+# Set up a service provider. We'll use this same provider for ALG
+from ocean_lib.data_provider.data_service_provider import DataServiceProvider
+provider_url = DataServiceProvider.get_url(ocean.config)
+# returns "http://localhost:8030"
+
+# Calc DATA service compute descriptor
+from ocean_lib.common.agreements.service_factory import ServiceDescriptor
+DATA_compute_service_descriptor = ServiceDescriptor.compute_service_descriptor(DATA_service_attributes, provider_url)
+
+#Publish metadata and service info on-chain
+DATA_ddo = ocean.assets.create(
+  metadata=DATA_metadata, # {"main" : {"type" : "dataset", ..}, ..}
+  publisher_wallet=alice_wallet,
+  service_descriptors=[DATA_compute_service_descriptor], # [("compute", {"attributes": ..})]
+  data_token_address=DATA_datatoken.address)
+print(f"DATA did = '{DATA_ddo.did}'")
+```
+
+Full details: [DATA_ddo](DATA_ddo.md)
+
+
+## 3. Alice publishes algorithm
+
+For this step, there are some prerequisites needed. If you want to replace the sample algorithm with an algorithm of your choosing, you will need to do some dependency management.
+You can use one of the standard [Ocean algo_dockers images](https://github.com/oceanprotocol/algo_dockers) or publish a custom docker image.
+Use the image name and tag in the `container` part of the algorithm metadata.
+This docker image needs to have basic support for dependency installation e.g. in the case of Python, OS-level library installations, pip installations etc.
+Take a look at the [Ocean tutorials](https://docs.oceanprotocol.com/tutorials/compute-to-data-algorithms/) to learn more about docker image publishing.
+
+In the same Python console:
+```python
+# Publish ALG datatoken
+ALG_datatoken = ocean.create_data_token('ALG1', 'ALG1', alice_wallet, blob=ocean.config.metadata_cache_uri)
+ALG_datatoken.mint(alice_wallet.address, to_wei(100), alice_wallet)
+print(f"ALG_datatoken.address = '{ALG_datatoken.address}'")
+
+# Specify metadata and service attributes, for "GPR" algorithm script.
+# In same location as Branin test dataset. GPR = Gaussian Process Regression.
+ALG_metadata =  {
+    "main": {
+        "type": "algorithm",
+        "algorithm": {
+            "language": "python",
+            "format": "docker-image",
+            "version": "0.1",
+            "container": {
+              "entrypoint": "python $ALGO",
+              "image": "oceanprotocol/algo_dockers",
+              "tag": "python-branin"
+            }
+        },
+        "files": [
+	  {
+	    "url": "https://raw.githubusercontent.com/trentmc/branin/main/gpr.py",
+	    "index": 0,
+	    "contentType": "text/text",
+	  }
+	],
+	"name": "gpr", "author": "Trent", "license": "CC0",
+	"dateCreated": "2020-01-28T10:55:11Z"
+    }
+}
+ALG_service_attributes = {
+        "main": {
+            "name": "ALG_dataAssetAccessServiceAgreement",
+            "creator": alice_wallet.address,
+            "timeout": 3600 * 24,
+            "datePublished": "2020-01-28T10:55:11Z",
+            "cost": 1.0, # <don't change, this is obsolete>
+        }
+    }
+
+# Calc ALG service access descriptor. We use the same service provider as DATA
+ALG_access_service_descriptor = ServiceDescriptor.access_service_descriptor(ALG_service_attributes, provider_url)
+#returns ("algorithm",
+#         {"attributes": ALG_service_attributes, "serviceEndpoint": provider_url})
+
+# Publish metadata and service info on-chain
+ALG_ddo = ocean.assets.create(
+  metadata=ALG_metadata, # {"main" : {"type" : "algorithm", ..}, ..}
+  publisher_wallet=alice_wallet,
+  service_descriptors=[ALG_access_service_descriptor],
+  data_token_address=ALG_datatoken.address)
+print(f"ALG did = '{ALG_ddo.did}'")
+```
+
+Full details: [ALG_ddo](ALG_ddo.md)
+
+Please note that this example features a simple Python algorithm. If you publish an algorithm in another language, make sure you have an appropriate container to run it, including dependencies.
+You can find more information about how to do this in the [Ocean tutorials](https://docs.oceanprotocol.com/tutorials/compute-to-data-algorithms/).
+
+## 4. Alice allows the algorithm for C2D for that data asset
+
+In the same Python console:
+```python
+from ocean_lib.assets import utils
+utils.add_publisher_trusted_algorithm(DATA_ddo, ALG_ddo.did, config.metadata_cache_uri)
+ocean.assets.update(DATA_ddo, publisher_wallet=alice_wallet)
+```
+
+## 5. Bob acquires datatokens for data and algorithm
+
+In the same Python console:
+```python
+bob_wallet = Wallet(ocean.web3, os.getenv('TEST_PRIVATE_KEY2'), config.block_confirmations)
+print(f"bob_wallet.address = '{bob_wallet.address}'")
+
+# Alice shares access for both to Bob, as datatokens. Alternatively, Bob might have bought these in a market.
+DATA_datatoken.transfer(bob_wallet.address, to_wei(5), from_wallet=alice_wallet)
+ALG_datatoken.transfer(bob_wallet.address, to_wei(5), from_wallet=alice_wallet)
+```
+
+## 6. Bob starts a compute job
+
+Only inputs needed: DATA_did, ALG_did. Everything else can get computed as needed.
+
+In the same Python console:
+```python
+DATA_did = DATA_ddo.did  # for convenience
+ALG_did = ALG_ddo.did
+DATA_DDO = ocean.assets.resolve(DATA_did)  # make sure we operate on the updated and indexed metadata_cache_uri versions
+ALG_DDO = ocean.assets.resolve(ALG_did)
+
+compute_service = DATA_DDO.get_service('compute')
+algo_service = ALG_DDO.get_service('access')
+
+from ocean_lib.web3_internal.constants import ZERO_ADDRESS
+from ocean_lib.models.compute_input import ComputeInput
+
+# order & pay for dataset
+dataset_order_requirements = ocean.assets.order(
+    DATA_did, bob_wallet.address, service_type=compute_service.type
+)
+DATA_order_tx_id = ocean.assets.pay_for_service(
+        ocean.web3,
+        dataset_order_requirements.amount,
+        dataset_order_requirements.data_token_address,
+        DATA_did,
+        compute_service.index,
+        ZERO_ADDRESS,
+        bob_wallet,
+        dataset_order_requirements.computeAddress,
+    )
+
+# order & pay for algo
+algo_order_requirements = ocean.assets.order(
+    ALG_did, bob_wallet.address, service_type=algo_service.type
+)
+ALG_order_tx_id = ocean.assets.pay_for_service(
+        ocean.web3,
+        algo_order_requirements.amount,
+        algo_order_requirements.data_token_address,
+        ALG_did,
+        algo_service.index,
+        ZERO_ADDRESS,
+        bob_wallet,
+        algo_order_requirements.computeAddress,
+)
+
+compute_inputs = [ComputeInput(DATA_did, DATA_order_tx_id, compute_service.index)]
+job_id = ocean.compute.start(
+    compute_inputs,
+    bob_wallet,
+    algorithm_did=ALG_did,
+    algorithm_tx_id=ALG_order_tx_id,
+    algorithm_data_token=ALG_datatoken.address
+)
+print(f"Started compute job with id: {job_id}")
+```
+
+## 7. Bob monitors logs / algorithm output
+
+In the same Python console, you can check the job status as many times as needed:
+
+```python
+ocean.compute.status(DATA_did, job_id, bob_wallet)
+
+```
+
+This will output the status of the current job.
+Here is a list of possible results: [Operator Service Status description](https://github.com/oceanprotocol/operator-service/blob/main/API.md#status-description).
+
+Once you get `{'ok': True, 'status': 70, 'statusText': 'Job finished'}`, Bob can check the result of the job.
+
+```python
+result = ocean.compute.result_file(DATA_did, job_id, 0, bob_wallet)  # 0 index, means we retrieve the results from the first dataset index
+
+import pickle
+model = pickle.loads(result)  # the gaussian model result
+```
+
+You can use the result however you like. For the purpose of this example, let's plot it.
+```python
+import numpy
+from matplotlib import pyplot
+
+X0_vec = numpy.linspace(-5., 10., 15)
+X1_vec = numpy.linspace(0., 15., 15)
+X0, X1 = numpy.meshgrid(X0_vec, X1_vec)
+b, c, t = 0.12918450914398066, 1.5915494309189535, 0.039788735772973836
+u = X1 - b*X0**2 + c*X0 - 6
+r = 10.*(1. - t) * numpy.cos(X0) + 10
+Z = u**2 + r
+
+fig, ax = pyplot.subplots(subplot_kw={"projection": "3d"})
+ax.scatter(X0, X1, model, c="r", label="model")
+pyplot.title("Data + model")
+pyplot.show() # or pyplot.savefig("test.png") to save the plot as a .png file instead
+```
+
+You should see something like this:
+
+![test](https://user-images.githubusercontent.com/4101015/134895548-82e8ede8-d0db-433a-b37e-694de390bca3.png)

--- a/markdowns/ocean-py/READMEs/datatokens-flow.md
+++ b/markdowns/ocean-py/READMEs/datatokens-flow.md
@@ -3,8 +3,8 @@ title: datatokens-flow.md
 slug: READMEs/datatokens-flow.md
 app: ocean.py
 module: READMEs.datatokens-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/datatokens-flow.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/datatokens-flow.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/datatokens-flow.md
+++ b/markdowns/ocean-py/READMEs/datatokens-flow.md
@@ -3,7 +3,7 @@ title: datatokens-flow.md
 slug: READMEs/datatokens-flow.md
 app: ocean.py
 module: READMEs.datatokens-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/datatokens-flow.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/datatokens-flow.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/developers.md
+++ b/markdowns/ocean-py/READMEs/developers.md
@@ -3,8 +3,8 @@ title: developers.md
 slug: READMEs/developers.md
 app: ocean.py
 module: READMEs.developers
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/developers.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/developers.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/developers.md
+++ b/markdowns/ocean-py/READMEs/developers.md
@@ -3,7 +3,7 @@ title: developers.md
 slug: READMEs/developers.md
 app: ocean.py
 module: READMEs.developers
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/developers.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/developers.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/dispenser-flow.md
+++ b/markdowns/ocean-py/READMEs/dispenser-flow.md
@@ -3,8 +3,8 @@ title: dispenser-flow.md
 slug: READMEs/dispenser-flow.md
 app: ocean.py
 module: READMEs.dispenser-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/dispenser-flow.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/dispenser-flow.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/dispenser-flow.md
+++ b/markdowns/ocean-py/READMEs/dispenser-flow.md
@@ -3,7 +3,7 @@ title: dispenser-flow.md
 slug: READMEs/dispenser-flow.md
 app: ocean.py
 module: READMEs.dispenser-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/dispenser-flow.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/dispenser-flow.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/fixed-rate-exchange-flow.md
+++ b/markdowns/ocean-py/READMEs/fixed-rate-exchange-flow.md
@@ -3,7 +3,7 @@ title: fixed-rate-exchange-flow.md
 slug: READMEs/fixed-rate-exchange-flow.md
 app: ocean.py
 module: READMEs.fixed-rate-exchange-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/fixed-rate-exchange-flow.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/fixed-rate-exchange-flow.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/fixed-rate-exchange-flow.md
+++ b/markdowns/ocean-py/READMEs/fixed-rate-exchange-flow.md
@@ -3,8 +3,8 @@ title: fixed-rate-exchange-flow.md
 slug: READMEs/fixed-rate-exchange-flow.md
 app: ocean.py
 module: READMEs.fixed-rate-exchange-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/fixed-rate-exchange-flow.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/fixed-rate-exchange-flow.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/marketplace-flow.md
+++ b/markdowns/ocean-py/READMEs/marketplace-flow.md
@@ -3,7 +3,7 @@ title: marketplace-flow.md
 slug: READMEs/marketplace-flow.md
 app: ocean.py
 module: READMEs.marketplace-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/marketplace-flow.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/marketplace-flow.md
 version: 0.8.1
 ---
 <!--
@@ -198,7 +198,7 @@ print(f"did = '{did}'")
 
 In order to encrypt the entire asset, when using a private market or metadata cache, use the encrypt keyword:
 `asset = ocean.assets.create(..., encrypt=True)`
-
+```python
 #Mint the datatokens
 from ocean_lib.web3_internal.currency import to_wei
 data_token.mint(alice_wallet.address, to_wei(100), alice_wallet)
@@ -278,7 +278,8 @@ print(f"Bob has {pretty_ether_and_wei(data_token.balanceOf(bob_wallet.address), 
 assert data_token.balanceOf(bob_wallet.address) >= to_wei(1), "Bob didn't get 1.0 datatokens"
 
 #Bob points to the service object
-fee_receiver = None # could also be market address
+from ocean_lib.web3_internal.constants import ZERO_ADDRESS
+fee_receiver = ZERO_ADDRESS # could also be market address
 from ocean_lib.common.agreements.service_types import ServiceTypes
 asset = ocean.assets.resolve(did)
 service = asset.get_service(ServiceTypes.ASSET_ACCESS)

--- a/markdowns/ocean-py/READMEs/marketplace-flow.md
+++ b/markdowns/ocean-py/READMEs/marketplace-flow.md
@@ -3,8 +3,8 @@ title: marketplace-flow.md
 slug: READMEs/marketplace-flow.md
 app: ocean.py
 module: READMEs.marketplace-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/marketplace-flow.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/marketplace-flow.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation
@@ -194,6 +194,7 @@ assert token_address == asset.data_token_address
 
 did = asset.did  # did contains the datatoken address
 print(f"did = '{did}'")
+```
 
 In order to encrypt the entire asset, when using a private market or metadata cache, use the encrypt keyword:
 `asset = ocean.assets.create(..., encrypt=True)`

--- a/markdowns/ocean-py/READMEs/overview.md
+++ b/markdowns/ocean-py/READMEs/overview.md
@@ -3,7 +3,7 @@ title: overview.md
 slug: READMEs/overview.md
 app: ocean.py
 module: READMEs.overview
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/overview.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/overview.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/overview.md
+++ b/markdowns/ocean-py/READMEs/overview.md
@@ -3,8 +3,8 @@ title: overview.md
 slug: READMEs/overview.md
 app: ocean.py
 module: READMEs.overview
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/overview.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/overview.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/parameters.md
+++ b/markdowns/ocean-py/READMEs/parameters.md
@@ -3,8 +3,8 @@ title: parameters.md
 slug: READMEs/parameters.md
 app: ocean.py
 module: READMEs.parameters
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/parameters.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/parameters.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/parameters.md
+++ b/markdowns/ocean-py/READMEs/parameters.md
@@ -3,7 +3,7 @@ title: parameters.md
 slug: READMEs/parameters.md
 app: ocean.py
 module: READMEs.parameters
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/parameters.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/parameters.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/release-process.md
+++ b/markdowns/ocean-py/READMEs/release-process.md
@@ -3,7 +3,7 @@ title: release-process.md
 slug: READMEs/release-process.md
 app: ocean.py
 module: READMEs.release-process
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/release-process.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/release-process.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/release-process.md
+++ b/markdowns/ocean-py/READMEs/release-process.md
@@ -3,8 +3,8 @@ title: release-process.md
 slug: READMEs/release-process.md
 app: ocean.py
 module: READMEs.release-process
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/release-process.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/release-process.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation
@@ -58,25 +58,16 @@ This doesn't actually affect the pip release of the following steps. And if you'
   - Describe the main changes. (In the future, these will come from the changelog.)
   - Click "Publish release".
 
+### Numbering versions
+Ocean.py is still in v3. We now use a marketing version numbering convention, where non-breaking changes should be patches, and breaking changes warrant minor releases.
+Once we integrate the v4 contracts, Ocean.py will be fully SEMVER compatible.
+
 ## Step 4: Verifiy
 
-- Travis will detect the release (a new tag) and run the deployment section of [.travis.yml](.travis.yml), i.e.
-
-  ```yaml
-  deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: ${PYPI_USER}
-  password: ${PYPI_PASSWORD}
-  on:
-    tags: true
-    repo: oceanprotocol/ocean.py
-    python: 3.8
-  ```
-
-- Go to [ocean.py Travis page](https://travis-ci.com/github/oceanprotocol/ocean.py) and check the Travis job. It should deploy a new release to PyPI.
+- GitHub Actions will detect the release (a new tag) and run the deployment and publishing to PyPi.
 
 - Check PyPI for the new release at <https://pypi.org/project/ocean-lib/>
 
 - Go through the [simple quickstart](datatokens-flow.md), ensure it works.
+
 - Go through the [marketplace quickstart](marketplace-flow.md), ensure it works.

--- a/markdowns/ocean-py/READMEs/services.md
+++ b/markdowns/ocean-py/READMEs/services.md
@@ -3,7 +3,7 @@ title: services.md
 slug: READMEs/services.md
 app: ocean.py
 module: READMEs.services
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/services.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/services.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/READMEs/services.md
+++ b/markdowns/ocean-py/READMEs/services.md
@@ -3,8 +3,8 @@ title: services.md
 slug: READMEs/services.md
 app: ocean.py
 module: READMEs.services
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/services.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/services.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/wallets.md
+++ b/markdowns/ocean-py/READMEs/wallets.md
@@ -3,8 +3,8 @@ title: wallets.md
 slug: READMEs/wallets.md
 app: ocean.py
 module: READMEs.wallets
-source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/wallets.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/wallets.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/READMEs/wallets.md
+++ b/markdowns/ocean-py/READMEs/wallets.md
@@ -3,7 +3,7 @@ title: wallets.md
 slug: READMEs/wallets.md
 app: ocean.py
 module: READMEs.wallets
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/READMEs/wallets.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/READMEs/wallets.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/ocean_lib/assets/asset.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset.md
@@ -3,7 +3,7 @@ title: asset
 slug: ocean_lib/assets/asset
 app: ocean.py
 module: ocean_lib.assets.asset
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/asset.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/asset.py
 version: 0.8.1
 ---
 ## Asset

--- a/markdowns/ocean-py/ocean_lib/assets/asset.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset.md
@@ -3,8 +3,8 @@ title: asset
 slug: ocean_lib/assets/asset
 app: ocean.py
 module: ocean_lib.assets.asset
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/asset.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/asset.py
+version: 0.8.1
 ---
 ## Asset
 

--- a/markdowns/ocean-py/ocean_lib/assets/asset_downloader.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset_downloader.md
@@ -3,8 +3,8 @@ title: asset_downloader
 slug: ocean_lib/assets/asset_downloader
 app: ocean.py
 module: ocean_lib.assets.asset_downloader
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/asset_downloader.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/asset_downloader.py
+version: 0.8.1
 ---
 #### download\_asset\_files
 

--- a/markdowns/ocean-py/ocean_lib/assets/asset_downloader.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset_downloader.md
@@ -3,7 +3,7 @@ title: asset_downloader
 slug: ocean_lib/assets/asset_downloader
 app: ocean.py
 module: ocean_lib.assets.asset_downloader
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/asset_downloader.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/asset_downloader.py
 version: 0.8.1
 ---
 #### download\_asset\_files

--- a/markdowns/ocean-py/ocean_lib/assets/asset_resolver.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset_resolver.md
@@ -3,7 +3,7 @@ title: asset_resolver
 slug: ocean_lib/assets/asset_resolver
 app: ocean.py
 module: ocean_lib.assets.asset_resolver
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/asset_resolver.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/asset_resolver.py
 version: 0.8.1
 ---
 DID Resolver module.

--- a/markdowns/ocean-py/ocean_lib/assets/asset_resolver.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset_resolver.md
@@ -3,8 +3,8 @@ title: asset_resolver
 slug: ocean_lib/assets/asset_resolver
 app: ocean.py
 module: ocean_lib.assets.asset_resolver
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/asset_resolver.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/asset_resolver.py
+version: 0.8.1
 ---
 DID Resolver module.
 

--- a/markdowns/ocean-py/ocean_lib/assets/utils.md
+++ b/markdowns/ocean-py/ocean_lib/assets/utils.md
@@ -3,7 +3,7 @@ title: utils
 slug: ocean_lib/assets/utils
 app: ocean.py
 module: ocean_lib.assets.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/utils.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/utils.py
 version: 0.8.1
 ---
 #### create\_checksum

--- a/markdowns/ocean-py/ocean_lib/assets/utils.md
+++ b/markdowns/ocean-py/ocean_lib/assets/utils.md
@@ -3,8 +3,8 @@ title: utils
 slug: ocean_lib/assets/utils
 app: ocean.py
 module: ocean_lib.assets.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/assets/utils.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/assets/utils.py
+version: 0.8.1
 ---
 #### create\_checksum
 

--- a/markdowns/ocean-py/ocean_lib/common/agreements/consumable.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/consumable.md
@@ -3,7 +3,7 @@ title: consumable
 slug: ocean_lib/common/agreements/consumable
 app: ocean.py
 module: ocean_lib.common.agreements.consumable
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/consumable.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/consumable.py
 version: 0.8.1
 ---
 ## ConsumableCodes

--- a/markdowns/ocean-py/ocean_lib/common/agreements/consumable.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/consumable.md
@@ -3,8 +3,8 @@ title: consumable
 slug: ocean_lib/common/agreements/consumable
 app: ocean.py
 module: ocean_lib.common.agreements.consumable
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/consumable.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/consumable.py
+version: 0.8.1
 ---
 ## ConsumableCodes
 

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_agreement.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_agreement.md
@@ -3,7 +3,7 @@ title: service_agreement
 slug: ocean_lib/common/agreements/service_agreement
 app: ocean.py
 module: ocean_lib.common.agreements.service_agreement
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/service_agreement.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/service_agreement.py
 version: 0.8.1
 ---
 ## ServiceAgreement

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_agreement.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_agreement.md
@@ -3,8 +3,8 @@ title: service_agreement
 slug: ocean_lib/common/agreements/service_agreement
 app: ocean.py
 module: ocean_lib.common.agreements.service_agreement
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/service_agreement.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/service_agreement.py
+version: 0.8.1
 ---
 ## ServiceAgreement
 

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_factory.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_factory.md
@@ -3,7 +3,7 @@ title: service_factory
 slug: ocean_lib/common/agreements/service_factory
 app: ocean.py
 module: ocean_lib.common.agreements.service_factory
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/service_factory.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/service_factory.py
 version: 0.8.1
 ---
 ## ServiceDescriptor

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_factory.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_factory.md
@@ -3,8 +3,8 @@ title: service_factory
 slug: ocean_lib/common/agreements/service_factory
 app: ocean.py
 module: ocean_lib.common.agreements.service_factory
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/service_factory.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/service_factory.py
+version: 0.8.1
 ---
 ## ServiceDescriptor
 

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_types.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_types.md
@@ -3,7 +3,7 @@ title: service_types
 slug: ocean_lib/common/agreements/service_types
 app: ocean.py
 module: ocean_lib.common.agreements.service_types
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/service_types.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/service_types.py
 version: 0.8.1
 ---
 Agreements module.

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_types.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_types.md
@@ -3,8 +3,8 @@ title: service_types
 slug: ocean_lib/common/agreements/service_types
 app: ocean.py
 module: ocean_lib.common.agreements.service_types
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/agreements/service_types.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/agreements/service_types.py
+version: 0.8.1
 ---
 Agreements module.
 

--- a/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius.md
+++ b/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius.md
@@ -3,8 +3,8 @@ title: aquarius
 slug: ocean_lib/common/aquarius/aquarius
 app: ocean.py
 module: ocean_lib.common.aquarius.aquarius
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/aquarius/aquarius.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/aquarius/aquarius.py
+version: 0.8.1
 ---
 Aquarius module.
 Help to communicate with the metadata store.
@@ -60,7 +60,7 @@ Return the url of the the Aquarius ddo encryption endpoint
 
 ```python
  | @enforce_types
- | def get_asset_ddo(did: str) -> Union[DDO, dict]
+ | def get_asset_ddo(did: str) -> Optional[DDO]
 ```
 
 Retrieve asset ddo for a given did.
@@ -107,43 +107,11 @@ Retrieve asset metadata for a given did.
 
 metadata key of the DDO instance
 
-#### text\_search
-
-```python
- | @enforce_types
- | def text_search(text: str, sort: Optional[dict] = None, offset: Optional[int] = 100, page: Optional[int] = 1) -> list
-```
-
-Search in aquarius using text query.
-
-Given the string aquarius will do a full-text query to search in all documents.
-
-Currently implemented are the MongoDB and Elastic Search drivers.
-
-For a detailed guide on how to search, see the MongoDB driver documentation:
-mongodb driverCurrently implemented in:
-https://docs.mongodb.com/manual/reference/operator/query/text/
-
-And the Elastic Search documentation:
-https://www.elastic.co/guide/en/elasticsearch/guide/current/full-text-search.html
-Other drivers are possible according to each implementation.
-
-**Arguments**:
-
-- `text`: String to be search.
-- `sort`: 1/-1 to sort ascending or descending.
-- `offset`: Integer with the number of elements displayed per page.
-- `page`: Integer with the number of page.
-
-**Returns**:
-
-List of DDO instance
-
 #### query\_search
 
 ```python
  | @enforce_types
- | def query_search(search_query: dict, sort: Optional[dict] = None, offset: Optional[int] = 100, page: Optional[int] = 1) -> list
+ | def query_search(search_query: dict) -> list
 ```
 
 Search using a query.
@@ -158,10 +126,7 @@ Example: query_search({"price":[0,10]})
 
 **Arguments**:
 
-- `search_query`: Python dictionary, query following mongodb syntax
-- `sort`: 1/-1 to sort ascending or descending.
-- `offset`: Integer with the number of elements displayed per page.
-- `page`: Integer with the number of page.
+- `search_query`: Python dictionary, query following elasticsearch syntax
 
 **Returns**:
 

--- a/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius.md
+++ b/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius.md
@@ -3,7 +3,7 @@ title: aquarius
 slug: ocean_lib/common/aquarius/aquarius
 app: ocean.py
 module: ocean_lib.common.aquarius.aquarius
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/aquarius/aquarius.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/aquarius/aquarius.py
 version: 0.8.1
 ---
 Aquarius module.

--- a/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius_provider.md
+++ b/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius_provider.md
@@ -3,7 +3,7 @@ title: aquarius_provider
 slug: ocean_lib/common/aquarius/aquarius_provider
 app: ocean.py
 module: ocean_lib.common.aquarius.aquarius_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/aquarius/aquarius_provider.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/aquarius/aquarius_provider.py
 version: 0.8.1
 ---
 ## AquariusProvider

--- a/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius_provider.md
+++ b/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius_provider.md
@@ -3,8 +3,8 @@ title: aquarius_provider
 slug: ocean_lib/common/aquarius/aquarius_provider
 app: ocean.py
 module: ocean_lib.common.aquarius.aquarius_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/aquarius/aquarius_provider.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/aquarius/aquarius_provider.py
+version: 0.8.1
 ---
 ## AquariusProvider
 

--- a/markdowns/ocean-py/ocean_lib/common/ddo/README.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/README.md
@@ -3,7 +3,7 @@ title: README.md
 slug: ocean_lib/common/ddo/README.md
 app: ocean.py
 module: ocean_lib.common.ddo.README
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/README.md
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/README.md
 version: 0.8.1
 ---
 <!--

--- a/markdowns/ocean-py/ocean_lib/common/ddo/README.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/README.md
@@ -3,8 +3,8 @@ title: README.md
 slug: ocean_lib/common/ddo/README.md
 app: ocean.py
 module: ocean_lib.common.ddo.README
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/README.md
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/README.md
+version: 0.8.1
 ---
 <!--
 Copyright 2021 Ocean Protocol Foundation

--- a/markdowns/ocean-py/ocean_lib/common/ddo/constants.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/constants.md
@@ -3,7 +3,7 @@ title: constants
 slug: ocean_lib/common/ddo/constants
 app: ocean.py
 module: ocean_lib.common.ddo.constants
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/constants.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/constants.py
 version: 0.8.1
 ---
 Contains constant values for

--- a/markdowns/ocean-py/ocean_lib/common/ddo/constants.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/constants.md
@@ -3,8 +3,8 @@ title: constants
 slug: ocean_lib/common/ddo/constants
 app: ocean.py
 module: ocean_lib.common.ddo.constants
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/constants.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/constants.py
+version: 0.8.1
 ---
 Contains constant values for
 - `DID_DDO_CONTEXT_URL`

--- a/markdowns/ocean-py/ocean_lib/common/ddo/credentials.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/credentials.md
@@ -3,8 +3,8 @@ title: credentials
 slug: ocean_lib/common/ddo/credentials
 app: ocean.py
 module: ocean_lib.common.ddo.credentials
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/credentials.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/credentials.py
+version: 0.8.1
 ---
 ## AddressCredential
 

--- a/markdowns/ocean-py/ocean_lib/common/ddo/credentials.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/credentials.md
@@ -3,7 +3,7 @@ title: credentials
 slug: ocean_lib/common/ddo/credentials
 app: ocean.py
 module: ocean_lib.common.ddo.credentials
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/credentials.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/credentials.py
 version: 0.8.1
 ---
 ## AddressCredential

--- a/markdowns/ocean-py/ocean_lib/common/ddo/ddo.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/ddo.md
@@ -3,7 +3,7 @@ title: ddo
 slug: ocean_lib/common/ddo/ddo
 app: ocean.py
 module: ocean_lib.common.ddo.ddo
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/ddo.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/ddo.py
 version: 0.8.1
 ---
 ## DDO

--- a/markdowns/ocean-py/ocean_lib/common/ddo/ddo.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/ddo.md
@@ -3,8 +3,8 @@ title: ddo
 slug: ocean_lib/common/ddo/ddo
 app: ocean.py
 module: ocean_lib.common.ddo.ddo
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/ddo.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/ddo.py
+version: 0.8.1
 ---
 ## DDO
 

--- a/markdowns/ocean-py/ocean_lib/common/ddo/service.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/service.md
@@ -3,8 +3,8 @@ title: service
 slug: ocean_lib/common/ddo/service
 app: ocean.py
 module: ocean_lib.common.ddo.service
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/service.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/service.py
+version: 0.8.1
 ---
 Service Class
 To handle service items in a DDO record

--- a/markdowns/ocean-py/ocean_lib/common/ddo/service.md
+++ b/markdowns/ocean-py/ocean_lib/common/ddo/service.md
@@ -3,7 +3,7 @@ title: service
 slug: ocean_lib/common/ddo/service
 app: ocean.py
 module: ocean_lib.common.ddo.service
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/ddo/service.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/ddo/service.py
 version: 0.8.1
 ---
 Service Class

--- a/markdowns/ocean-py/ocean_lib/common/did.md
+++ b/markdowns/ocean-py/ocean_lib/common/did.md
@@ -3,7 +3,7 @@ title: did
 slug: ocean_lib/common/did
 app: ocean.py
 module: ocean_lib.common.did
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/did.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/did.py
 version: 0.8.1
 ---
 DID Lib to do DID's and DDO's.

--- a/markdowns/ocean-py/ocean_lib/common/did.md
+++ b/markdowns/ocean-py/ocean_lib/common/did.md
@@ -3,8 +3,8 @@ title: did
 slug: ocean_lib/common/did
 app: ocean.py
 module: ocean_lib.common.did
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/did.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/did.py
+version: 0.8.1
 ---
 DID Lib to do DID's and DDO's.
 

--- a/markdowns/ocean-py/ocean_lib/common/http_requests/requests_session.md
+++ b/markdowns/ocean-py/ocean_lib/common/http_requests/requests_session.md
@@ -3,7 +3,7 @@ title: requests_session
 slug: ocean_lib/common/http_requests/requests_session
 app: ocean.py
 module: ocean_lib.common.http_requests.requests_session
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/http_requests/requests_session.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/http_requests/requests_session.py
 version: 0.8.1
 ---
 #### get\_requests\_session

--- a/markdowns/ocean-py/ocean_lib/common/http_requests/requests_session.md
+++ b/markdowns/ocean-py/ocean_lib/common/http_requests/requests_session.md
@@ -3,8 +3,8 @@ title: requests_session
 slug: ocean_lib/common/http_requests/requests_session
 app: ocean.py
 module: ocean_lib.common.http_requests.requests_session
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/http_requests/requests_session.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/http_requests/requests_session.py
+version: 0.8.1
 ---
 #### get\_requests\_session
 

--- a/markdowns/ocean-py/ocean_lib/common/utils/utilities.md
+++ b/markdowns/ocean-py/ocean_lib/common/utils/utilities.md
@@ -3,7 +3,7 @@ title: utilities
 slug: ocean_lib/common/utils/utilities
 app: ocean.py
 module: ocean_lib.common.utils.utilities
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/utils/utilities.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/utils/utilities.py
 version: 0.8.1
 ---
 Utilities class

--- a/markdowns/ocean-py/ocean_lib/common/utils/utilities.md
+++ b/markdowns/ocean-py/ocean_lib/common/utils/utilities.md
@@ -3,8 +3,8 @@ title: utilities
 slug: ocean_lib/common/utils/utilities
 app: ocean.py
 module: ocean_lib.common.utils.utilities
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/common/utils/utilities.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/common/utils/utilities.py
+version: 0.8.1
 ---
 Utilities class
 

--- a/markdowns/ocean-py/ocean_lib/config.md
+++ b/markdowns/ocean-py/ocean_lib/config.md
@@ -3,8 +3,8 @@ title: config
 slug: ocean_lib/config
 app: ocean.py
 module: ocean_lib.config
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/config.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/config.py
+version: 0.8.1
 ---
 ## Config
 

--- a/markdowns/ocean-py/ocean_lib/config.md
+++ b/markdowns/ocean-py/ocean_lib/config.md
@@ -3,7 +3,7 @@ title: config
 slug: ocean_lib/config
 app: ocean.py
 module: ocean_lib.config
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/config.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/config.py
 version: 0.8.1
 ---
 ## Config

--- a/markdowns/ocean-py/ocean_lib/data_provider/data_service_provider.md
+++ b/markdowns/ocean-py/ocean_lib/data_provider/data_service_provider.md
@@ -3,7 +3,7 @@ title: data_service_provider
 slug: ocean_lib/data_provider/data_service_provider
 app: ocean.py
 module: ocean_lib.data_provider.data_service_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/data_provider/data_service_provider.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/data_provider/data_service_provider.py
 version: 0.8.1
 ---
 Provider module.

--- a/markdowns/ocean-py/ocean_lib/data_provider/data_service_provider.md
+++ b/markdowns/ocean-py/ocean_lib/data_provider/data_service_provider.md
@@ -3,8 +3,8 @@ title: data_service_provider
 slug: ocean_lib/data_provider/data_service_provider
 app: ocean.py
 module: ocean_lib.data_provider.data_service_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/data_provider/data_service_provider.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/data_provider/data_service_provider.py
+version: 0.8.1
 ---
 Provider module.
 
@@ -199,6 +199,26 @@ status for each job_id that exist for the did
 
 dict of job_id to result urls. When job_id is not provided, this will return
 result for each job_id that exist for the did
+
+#### compute\_job\_result\_file
+
+```python
+ | @staticmethod
+ | @enforce_types
+ | def compute_job_result_file(job_id: str, index: int, service_endpoint: str, consumer_address: str, signature: str) -> Dict[str, Any]
+```
+
+**Arguments**:
+
+- `job_id`: str id of compute job that was returned from `start_compute_job`
+- `index`: int compute result index
+- `service_endpoint`: str url of the provider service endpoint for compute service
+- `consumer_address`: hex str the ethereum address of the consumer's account
+- `signature`: hex str signed message to allow the provider to authorize the consumer
+
+**Returns**:
+
+dict of job_id to result urls.
 
 #### get\_url
 

--- a/markdowns/ocean-py/ocean_lib/example_config.md
+++ b/markdowns/ocean-py/ocean_lib/example_config.md
@@ -3,8 +3,8 @@ title: example_config
 slug: ocean_lib/example_config
 app: ocean.py
 module: ocean_lib.example_config
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/example_config.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/example_config.py
+version: 0.8.1
 ---
 ## ExampleConfig
 

--- a/markdowns/ocean-py/ocean_lib/example_config.md
+++ b/markdowns/ocean-py/ocean_lib/example_config.md
@@ -3,7 +3,7 @@ title: example_config
 slug: ocean_lib/example_config
 app: ocean.py
 module: ocean_lib.example_config
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/example_config.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/example_config.py
 version: 0.8.1
 ---
 ## ExampleConfig

--- a/markdowns/ocean-py/ocean_lib/exceptions.md
+++ b/markdowns/ocean-py/ocean_lib/exceptions.md
@@ -3,8 +3,8 @@ title: exceptions
 slug: ocean_lib/exceptions
 app: ocean.py
 module: ocean_lib.exceptions
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/exceptions.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/exceptions.py
+version: 0.8.1
 ---
 ## OceanEncryptAssetUrlsError
 

--- a/markdowns/ocean-py/ocean_lib/exceptions.md
+++ b/markdowns/ocean-py/ocean_lib/exceptions.md
@@ -3,7 +3,7 @@ title: exceptions
 slug: ocean_lib/exceptions
 app: ocean.py
 module: ocean_lib.exceptions
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/exceptions.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/exceptions.py
 version: 0.8.1
 ---
 ## OceanEncryptAssetUrlsError

--- a/markdowns/ocean-py/ocean_lib/integer.md
+++ b/markdowns/ocean-py/ocean_lib/integer.md
@@ -3,6 +3,6 @@ title: integer
 slug: ocean_lib/integer
 app: ocean.py
 module: ocean_lib.integer
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/integer.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/integer.py
+version: 0.8.1
 ---

--- a/markdowns/ocean-py/ocean_lib/integer.md
+++ b/markdowns/ocean-py/ocean_lib/integer.md
@@ -3,6 +3,6 @@ title: integer
 slug: ocean_lib/integer
 app: ocean.py
 module: ocean_lib.integer
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/integer.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/integer.py
 version: 0.8.1
 ---

--- a/markdowns/ocean-py/ocean_lib/models/algorithm_metadata.md
+++ b/markdowns/ocean-py/ocean_lib/models/algorithm_metadata.md
@@ -3,8 +3,8 @@ title: algorithm_metadata
 slug: ocean_lib/models/algorithm_metadata
 app: ocean.py
 module: ocean_lib.models.algorithm_metadata
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/algorithm_metadata.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/algorithm_metadata.py
+version: 0.8.1
 ---
 ## AlgorithmMetadata
 

--- a/markdowns/ocean-py/ocean_lib/models/algorithm_metadata.md
+++ b/markdowns/ocean-py/ocean_lib/models/algorithm_metadata.md
@@ -3,7 +3,7 @@ title: algorithm_metadata
 slug: ocean_lib/models/algorithm_metadata
 app: ocean.py
 module: ocean_lib.models.algorithm_metadata
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/algorithm_metadata.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/algorithm_metadata.py
 version: 0.8.1
 ---
 ## AlgorithmMetadata

--- a/markdowns/ocean-py/ocean_lib/models/balancer_constants.md
+++ b/markdowns/ocean-py/ocean_lib/models/balancer_constants.md
@@ -3,8 +3,8 @@ title: balancer_constants
 slug: ocean_lib/models/balancer_constants
 app: ocean.py
 module: ocean_lib.models.balancer_constants
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/balancer_constants.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/balancer_constants.py
+version: 0.8.1
 ---
 Contains `Balancer` related constants for
 - `GASLIMIT_BFACTORY_NEWBPOOL`

--- a/markdowns/ocean-py/ocean_lib/models/balancer_constants.md
+++ b/markdowns/ocean-py/ocean_lib/models/balancer_constants.md
@@ -3,7 +3,7 @@ title: balancer_constants
 slug: ocean_lib/models/balancer_constants
 app: ocean.py
 module: ocean_lib.models.balancer_constants
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/balancer_constants.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/balancer_constants.py
 version: 0.8.1
 ---
 Contains `Balancer` related constants for

--- a/markdowns/ocean-py/ocean_lib/models/bfactory.md
+++ b/markdowns/ocean-py/ocean_lib/models/bfactory.md
@@ -3,8 +3,8 @@ title: bfactory
 slug: ocean_lib/models/bfactory
 app: ocean.py
 module: ocean_lib.models.bfactory
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/bfactory.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/bfactory.py
+version: 0.8.1
 ---
 ## BFactory
 

--- a/markdowns/ocean-py/ocean_lib/models/bfactory.md
+++ b/markdowns/ocean-py/ocean_lib/models/bfactory.md
@@ -3,7 +3,7 @@ title: bfactory
 slug: ocean_lib/models/bfactory
 app: ocean.py
 module: ocean_lib.models.bfactory
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/bfactory.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/bfactory.py
 version: 0.8.1
 ---
 ## BFactory

--- a/markdowns/ocean-py/ocean_lib/models/bpool.md
+++ b/markdowns/ocean-py/ocean_lib/models/bpool.md
@@ -3,8 +3,8 @@ title: bpool
 slug: ocean_lib/models/bpool
 app: ocean.py
 module: ocean_lib.models.bpool
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/bpool.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/bpool.py
+version: 0.8.1
 ---
 ## BPool
 

--- a/markdowns/ocean-py/ocean_lib/models/bpool.md
+++ b/markdowns/ocean-py/ocean_lib/models/bpool.md
@@ -3,7 +3,7 @@ title: bpool
 slug: ocean_lib/models/bpool
 app: ocean.py
 module: ocean_lib.models.bpool
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/bpool.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/bpool.py
 version: 0.8.1
 ---
 ## BPool

--- a/markdowns/ocean-py/ocean_lib/models/btoken.md
+++ b/markdowns/ocean-py/ocean_lib/models/btoken.md
@@ -3,7 +3,7 @@ title: btoken
 slug: ocean_lib/models/btoken
 app: ocean.py
 module: ocean_lib.models.btoken
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/btoken.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/btoken.py
 version: 0.8.1
 ---
 ## BToken

--- a/markdowns/ocean-py/ocean_lib/models/btoken.md
+++ b/markdowns/ocean-py/ocean_lib/models/btoken.md
@@ -3,8 +3,8 @@ title: btoken
 slug: ocean_lib/models/btoken
 app: ocean.py
 module: ocean_lib.models.btoken
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/btoken.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/btoken.py
+version: 0.8.1
 ---
 ## BToken
 

--- a/markdowns/ocean-py/ocean_lib/models/compute_input.md
+++ b/markdowns/ocean-py/ocean_lib/models/compute_input.md
@@ -3,8 +3,8 @@ title: compute_input
 slug: ocean_lib/models/compute_input
 app: ocean.py
 module: ocean_lib.models.compute_input
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/compute_input.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/compute_input.py
+version: 0.8.1
 ---
 ## ComputeInput
 

--- a/markdowns/ocean-py/ocean_lib/models/compute_input.md
+++ b/markdowns/ocean-py/ocean_lib/models/compute_input.md
@@ -3,7 +3,7 @@ title: compute_input
 slug: ocean_lib/models/compute_input
 app: ocean.py
 module: ocean_lib.models.compute_input
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/compute_input.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/compute_input.py
 version: 0.8.1
 ---
 ## ComputeInput

--- a/markdowns/ocean-py/ocean_lib/models/data_token.md
+++ b/markdowns/ocean-py/ocean_lib/models/data_token.md
@@ -3,7 +3,7 @@ title: data_token
 slug: ocean_lib/models/data_token
 app: ocean.py
 module: ocean_lib.models.data_token
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/data_token.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/data_token.py
 version: 0.8.1
 ---
 ## DataToken

--- a/markdowns/ocean-py/ocean_lib/models/data_token.md
+++ b/markdowns/ocean-py/ocean_lib/models/data_token.md
@@ -3,8 +3,8 @@ title: data_token
 slug: ocean_lib/models/data_token
 app: ocean.py
 module: ocean_lib.models.data_token
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/data_token.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/data_token.py
+version: 0.8.1
 ---
 ## DataToken
 

--- a/markdowns/ocean-py/ocean_lib/models/dispenser.md
+++ b/markdowns/ocean-py/ocean_lib/models/dispenser.md
@@ -3,7 +3,7 @@ title: dispenser
 slug: ocean_lib/models/dispenser
 app: ocean.py
 module: ocean_lib.models.dispenser
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/dispenser.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/dispenser.py
 version: 0.8.1
 ---
 ## DispenserContract

--- a/markdowns/ocean-py/ocean_lib/models/dispenser.md
+++ b/markdowns/ocean-py/ocean_lib/models/dispenser.md
@@ -3,8 +3,8 @@ title: dispenser
 slug: ocean_lib/models/dispenser
 app: ocean.py
 module: ocean_lib.models.dispenser
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/dispenser.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/dispenser.py
+version: 0.8.1
 ---
 ## DispenserContract
 

--- a/markdowns/ocean-py/ocean_lib/models/dtfactory.md
+++ b/markdowns/ocean-py/ocean_lib/models/dtfactory.md
@@ -3,8 +3,8 @@ title: dtfactory
 slug: ocean_lib/models/dtfactory
 app: ocean.py
 module: ocean_lib.models.dtfactory
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/dtfactory.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/dtfactory.py
+version: 0.8.1
 ---
 ## DTFactory
 

--- a/markdowns/ocean-py/ocean_lib/models/dtfactory.md
+++ b/markdowns/ocean-py/ocean_lib/models/dtfactory.md
@@ -3,7 +3,7 @@ title: dtfactory
 slug: ocean_lib/models/dtfactory
 app: ocean.py
 module: ocean_lib.models.dtfactory
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/dtfactory.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/dtfactory.py
 version: 0.8.1
 ---
 ## DTFactory

--- a/markdowns/ocean-py/ocean_lib/models/fixed_rate_exchange.md
+++ b/markdowns/ocean-py/ocean_lib/models/fixed_rate_exchange.md
@@ -3,7 +3,7 @@ title: fixed_rate_exchange
 slug: ocean_lib/models/fixed_rate_exchange
 app: ocean.py
 module: ocean_lib.models.fixed_rate_exchange
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/fixed_rate_exchange.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/fixed_rate_exchange.py
 version: 0.8.1
 ---
 ## FixedRateExchange

--- a/markdowns/ocean-py/ocean_lib/models/fixed_rate_exchange.md
+++ b/markdowns/ocean-py/ocean_lib/models/fixed_rate_exchange.md
@@ -3,8 +3,8 @@ title: fixed_rate_exchange
 slug: ocean_lib/models/fixed_rate_exchange
 app: ocean.py
 module: ocean_lib.models.fixed_rate_exchange
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/fixed_rate_exchange.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/fixed_rate_exchange.py
+version: 0.8.1
 ---
 ## FixedRateExchange
 

--- a/markdowns/ocean-py/ocean_lib/models/metadata.md
+++ b/markdowns/ocean-py/ocean_lib/models/metadata.md
@@ -3,8 +3,8 @@ title: metadata
 slug: ocean_lib/models/metadata
 app: ocean.py
 module: ocean_lib.models.metadata
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/metadata.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/metadata.py
+version: 0.8.1
 ---
 ## MetadataContract
 

--- a/markdowns/ocean-py/ocean_lib/models/metadata.md
+++ b/markdowns/ocean-py/ocean_lib/models/metadata.md
@@ -3,7 +3,7 @@ title: metadata
 slug: ocean_lib/models/metadata
 app: ocean.py
 module: ocean_lib.models.metadata
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/metadata.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/metadata.py
 version: 0.8.1
 ---
 ## MetadataContract

--- a/markdowns/ocean-py/ocean_lib/models/order.md
+++ b/markdowns/ocean-py/ocean_lib/models/order.md
@@ -3,7 +3,7 @@ title: order
 slug: ocean_lib/models/order
 app: ocean.py
 module: ocean_lib.models.order
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/order.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/order.py
 version: 0.8.1
 ---
 Defines namedtuple `Order`

--- a/markdowns/ocean-py/ocean_lib/models/order.md
+++ b/markdowns/ocean-py/ocean_lib/models/order.md
@@ -3,8 +3,8 @@ title: order
 slug: ocean_lib/models/order
 app: ocean.py
 module: ocean_lib.models.order
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/models/order.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/models/order.py
+version: 0.8.1
 ---
 Defines namedtuple `Order`
 

--- a/markdowns/ocean-py/ocean_lib/ocean/env_constants.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/env_constants.md
@@ -3,8 +3,8 @@ title: env_constants
 slug: ocean_lib/ocean/env_constants
 app: ocean.py
 module: ocean_lib.ocean.env_constants
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/env_constants.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/env_constants.py
+version: 0.8.1
 ---
 Defines constants:
 - `ENV_CONFIG_FILE`

--- a/markdowns/ocean-py/ocean_lib/ocean/env_constants.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/env_constants.md
@@ -3,7 +3,7 @@ title: env_constants
 slug: ocean_lib/ocean/env_constants
 app: ocean.py
 module: ocean_lib.ocean.env_constants
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/env_constants.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/env_constants.py
 version: 0.8.1
 ---
 Defines constants:

--- a/markdowns/ocean-py/ocean_lib/ocean/mint_fake_ocean.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/mint_fake_ocean.md
@@ -3,7 +3,7 @@ title: mint_fake_ocean
 slug: ocean_lib/ocean/mint_fake_ocean
 app: ocean.py
 module: ocean_lib.ocean.mint_fake_ocean
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/mint_fake_ocean.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/mint_fake_ocean.py
 version: 0.8.1
 ---
 #### mint\_fake\_OCEAN

--- a/markdowns/ocean-py/ocean_lib/ocean/mint_fake_ocean.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/mint_fake_ocean.md
@@ -3,8 +3,8 @@ title: mint_fake_ocean
 slug: ocean_lib/ocean/mint_fake_ocean
 app: ocean.py
 module: ocean_lib.ocean.mint_fake_ocean
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/mint_fake_ocean.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/mint_fake_ocean.py
+version: 0.8.1
 ---
 #### mint\_fake\_OCEAN
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean.md
@@ -3,8 +3,8 @@ title: ocean
 slug: ocean_lib/ocean/ocean
 app: ocean.py
 module: ocean_lib.ocean.ocean
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean.py
+version: 0.8.1
 ---
 Ocean module.
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean.md
@@ -3,7 +3,7 @@ title: ocean
 slug: ocean_lib/ocean/ocean
 app: ocean.py
 module: ocean_lib.ocean.ocean
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean.py
 version: 0.8.1
 ---
 Ocean module.

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_assets.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_assets.md
@@ -3,8 +3,8 @@ title: ocean_assets
 slug: ocean_lib/ocean/ocean_assets
 app: ocean.py
 module: ocean_lib.ocean.ocean_assets
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_assets.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_assets.py
+version: 0.8.1
 ---
 Ocean module.
 
@@ -80,7 +80,7 @@ Asset instance
 
 ```python
  | @enforce_types
- | def search(text: str, sort: Optional[dict] = None, offset: Optional[int] = 100, page: Optional[int] = 1, metadata_cache_uri: Optional[str] = None) -> list
+ | def search(text: str, metadata_cache_uri: Optional[str] = None) -> list
 ```
 
 Search an asset in oceanDB using aquarius.
@@ -88,9 +88,6 @@ Search an asset in oceanDB using aquarius.
 **Arguments**:
 
 - `text`: String with the value that you are searching
-- `sort`: Dictionary to choose order main in some value
-- `offset`: Number of elements shows by page
-- `page`: Page number
 - `metadata_cache_uri`: Url of the aquarius where you want to search. If there is not
 provided take the default
 
@@ -102,7 +99,7 @@ List of assets that match with the query
 
 ```python
  | @enforce_types
- | def query(query: dict, sort: Optional[dict] = None, offset: Optional[int] = 100, page: Optional[int] = 1, metadata_cache_uri: Optional[str] = None) -> list
+ | def query(query: dict, metadata_cache_uri: Optional[str] = None) -> list
 ```
 
 Search an asset in oceanDB using search query.
@@ -111,9 +108,6 @@ Search an asset in oceanDB using search query.
 
 - `query`: dict with query parameters
 (e.g.) https://github.com/oceanprotocol/aquarius/blob/develop/docs/for_api_users/API.md
-- `sort`: Dictionary to choose order main in some value
-- `offset`: Number of elements shows by page
-- `page`: Page number
 - `metadata_cache_uri`: Url of the aquarius where you want to search. If there is not
 provided take the default
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_assets.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_assets.md
@@ -3,7 +3,7 @@ title: ocean_assets
 slug: ocean_lib/ocean/ocean_assets
 app: ocean.py
 module: ocean_lib.ocean.ocean_assets
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_assets.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_assets.py
 version: 0.8.1
 ---
 Ocean module.

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_compute.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_compute.md
@@ -3,7 +3,7 @@ title: ocean_compute
 slug: ocean_lib/ocean/ocean_compute
 app: ocean.py
 module: ocean_lib.ocean.ocean_compute
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_compute.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_compute.py
 version: 0.8.1
 ---
 ## OceanCompute

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_compute.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_compute.md
@@ -3,8 +3,8 @@ title: ocean_compute
 slug: ocean_lib/ocean/ocean_compute
 app: ocean.py
 module: ocean_lib.ocean.ocean_compute
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_compute.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_compute.py
+version: 0.8.1
 ---
 ## OceanCompute
 
@@ -249,6 +249,25 @@ Gets job result.
 
 - `did`: str id of the asset offering the compute service of this job
 - `job_id`: str id of the compute job
+- `wallet`: Wallet instance
+
+**Returns**:
+
+dict the results/logs urls for an existing compute job, keys are (did, urls, logs)
+
+#### result\_file
+
+```python
+ | @enforce_types
+ | def result_file(did: str, job_id: str, index: int, wallet: Wallet) -> Dict[str, Any]
+```
+
+Gets job result.
+
+**Arguments**:
+
+- `job_id`: str id of the compute job
+- `index`: compute result index
 - `wallet`: Wallet instance
 
 **Returns**:

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_exchange.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_exchange.md
@@ -3,7 +3,7 @@ title: ocean_exchange
 slug: ocean_lib/ocean/ocean_exchange
 app: ocean.py
 module: ocean_lib.ocean.ocean_exchange
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_exchange.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_exchange.py
 version: 0.8.1
 ---
 ## OceanExchange

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_exchange.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_exchange.md
@@ -3,8 +3,8 @@ title: ocean_exchange
 slug: ocean_lib/ocean/ocean_exchange
 app: ocean.py
 module: ocean_lib.ocean.ocean_exchange
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_exchange.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_exchange.py
+version: 0.8.1
 ---
 ## OceanExchange
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_pool.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_pool.md
@@ -3,7 +3,7 @@ title: ocean_pool
 slug: ocean_lib/ocean/ocean_pool
 app: ocean.py
 module: ocean_lib.ocean.ocean_pool
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_pool.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_pool.py
 version: 0.8.1
 ---
 ## OceanPool

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_pool.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_pool.md
@@ -3,8 +3,8 @@ title: ocean_pool
 slug: ocean_lib/ocean/ocean_pool
 app: ocean.py
 module: ocean_lib.ocean.ocean_pool
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_pool.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_pool.py
+version: 0.8.1
 ---
 ## OceanPool
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_services.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_services.md
@@ -3,8 +3,8 @@ title: ocean_services
 slug: ocean_lib/ocean/ocean_services
 app: ocean.py
 module: ocean_lib.ocean.ocean_services
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_services.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_services.py
+version: 0.8.1
 ---
 Ocean module.
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_services.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_services.md
@@ -3,7 +3,7 @@ title: ocean_services
 slug: ocean_lib/ocean/ocean_services
 app: ocean.py
 module: ocean_lib.ocean.ocean_services
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/ocean_services.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/ocean_services.py
 version: 0.8.1
 ---
 Ocean module.

--- a/markdowns/ocean-py/ocean_lib/ocean/util.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/util.md
@@ -3,7 +3,7 @@ title: util
 slug: ocean_lib/ocean/util
 app: ocean.py
 module: ocean_lib.ocean.util
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/util.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/util.py
 version: 0.8.1
 ---
 #### get\_web3

--- a/markdowns/ocean-py/ocean_lib/ocean/util.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/util.md
@@ -3,8 +3,8 @@ title: util
 slug: ocean_lib/ocean/util
 app: ocean.py
 module: ocean_lib.ocean.util
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/ocean/util.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/ocean/util.py
+version: 0.8.1
 ---
 #### get\_web3
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/constants.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/constants.md
@@ -3,8 +3,8 @@ title: constants
 slug: ocean_lib/web3_internal/constants
 app: ocean.py
 module: ocean_lib.web3_internal.constants
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/constants.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/constants.py
+version: 0.8.1
 ---
 This module holds following default values for Gas price, Gas limit and more.
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/constants.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/constants.md
@@ -3,7 +3,7 @@ title: constants
 slug: ocean_lib/web3_internal/constants
 app: ocean.py
 module: ocean_lib.web3_internal.constants
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/constants.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/constants.py
 version: 0.8.1
 ---
 This module holds following default values for Gas price, Gas limit and more.

--- a/markdowns/ocean-py/ocean_lib/web3_internal/contract_base.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/contract_base.md
@@ -3,8 +3,8 @@ title: contract_base
 slug: ocean_lib/web3_internal/contract_base
 app: ocean.py
 module: ocean_lib.web3_internal.contract_base
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/contract_base.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/contract_base.py
+version: 0.8.1
 ---
 All contracts inherit from `ContractBase` class.
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/contract_base.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/contract_base.md
@@ -3,7 +3,7 @@ title: contract_base
 slug: ocean_lib/web3_internal/contract_base
 app: ocean.py
 module: ocean_lib.web3_internal.contract_base
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/contract_base.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/contract_base.py
 version: 0.8.1
 ---
 All contracts inherit from `ContractBase` class.

--- a/markdowns/ocean-py/ocean_lib/web3_internal/contract_utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/contract_utils.md
@@ -3,8 +3,8 @@ title: contract_utils
 slug: ocean_lib/web3_internal/contract_utils
 app: ocean.py
 module: ocean_lib.web3_internal.contract_utils
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/contract_utils.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/contract_utils.py
+version: 0.8.1
 ---
 #### get\_contract\_definition
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/contract_utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/contract_utils.md
@@ -3,7 +3,7 @@ title: contract_utils
 slug: ocean_lib/web3_internal/contract_utils
 app: ocean.py
 module: ocean_lib.web3_internal.contract_utils
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/contract_utils.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/contract_utils.py
 version: 0.8.1
 ---
 #### get\_contract\_definition

--- a/markdowns/ocean-py/ocean_lib/web3_internal/currency.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/currency.md
@@ -3,7 +3,7 @@ title: currency
 slug: ocean_lib/web3_internal/currency
 app: ocean.py
 module: ocean_lib.web3_internal.currency
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/currency.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/currency.py
 version: 0.8.1
 ---
 #### ETHEREUM\_DECIMAL\_CONTEXT

--- a/markdowns/ocean-py/ocean_lib/web3_internal/currency.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/currency.md
@@ -3,8 +3,8 @@ title: currency
 slug: ocean_lib/web3_internal/currency
 app: ocean.py
 module: ocean_lib.web3_internal.currency
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/currency.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/currency.py
+version: 0.8.1
 ---
 #### ETHEREUM\_DECIMAL\_CONTEXT
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/event_filter.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/event_filter.md
@@ -3,8 +3,8 @@ title: event_filter
 slug: ocean_lib/web3_internal/event_filter
 app: ocean.py
 module: ocean_lib.web3_internal.event_filter
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/event_filter.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/event_filter.py
+version: 0.8.1
 ---
 ## EventFilter
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/event_filter.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/event_filter.md
@@ -3,7 +3,7 @@ title: event_filter
 slug: ocean_lib/web3_internal/event_filter
 app: ocean.py
 module: ocean_lib.web3_internal.event_filter
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/event_filter.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/event_filter.py
 version: 0.8.1
 ---
 ## EventFilter

--- a/markdowns/ocean-py/ocean_lib/web3_internal/event_listener.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/event_listener.md
@@ -3,8 +3,8 @@ title: event_listener
 slug: ocean_lib/web3_internal/event_listener
 app: ocean.py
 module: ocean_lib.web3_internal.event_listener
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/event_listener.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/event_listener.py
+version: 0.8.1
 ---
 ## EventListener
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/event_listener.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/event_listener.md
@@ -3,7 +3,7 @@ title: event_listener
 slug: ocean_lib/web3_internal/event_listener
 app: ocean.py
 module: ocean_lib.web3_internal.event_listener
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/event_listener.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/event_listener.py
 version: 0.8.1
 ---
 ## EventListener

--- a/markdowns/ocean-py/ocean_lib/web3_internal/transactions.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/transactions.md
@@ -3,8 +3,8 @@ title: transactions
 slug: ocean_lib/web3_internal/transactions
 app: ocean.py
 module: ocean_lib.web3_internal.transactions
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/transactions.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/transactions.py
+version: 0.8.1
 ---
 #### sign\_hash
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/transactions.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/transactions.md
@@ -3,7 +3,7 @@ title: transactions
 slug: ocean_lib/web3_internal/transactions
 app: ocean.py
 module: ocean_lib.web3_internal.transactions
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/transactions.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/transactions.py
 version: 0.8.1
 ---
 #### sign\_hash

--- a/markdowns/ocean-py/ocean_lib/web3_internal/utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/utils.md
@@ -3,8 +3,8 @@ title: utils
 slug: ocean_lib/web3_internal/utils
 app: ocean.py
 module: ocean_lib.web3_internal.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/utils.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/utils.py
+version: 0.8.1
 ---
 #### generate\_multi\_value\_hash
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/utils.md
@@ -3,7 +3,7 @@ title: utils
 slug: ocean_lib/web3_internal/utils
 app: ocean.py
 module: ocean_lib.web3_internal.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/utils.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/utils.py
 version: 0.8.1
 ---
 #### generate\_multi\_value\_hash

--- a/markdowns/ocean-py/ocean_lib/web3_internal/wallet.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/wallet.md
@@ -3,8 +3,8 @@ title: wallet
 slug: ocean_lib/web3_internal/wallet
 app: ocean.py
 module: ocean_lib.web3_internal.wallet
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/wallet.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/wallet.py
+version: 0.8.1
 ---
 ## Wallet
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/wallet.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/wallet.md
@@ -3,7 +3,7 @@ title: wallet
 slug: ocean_lib/web3_internal/wallet
 app: ocean.py
 module: ocean_lib.web3_internal.wallet
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/wallet.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/wallet.py
 version: 0.8.1
 ---
 ## Wallet

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/contract.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/contract.md
@@ -3,7 +3,7 @@ title: contract
 slug: ocean_lib/web3_internal/web3_overrides/contract
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.contract
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/contract.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/contract.py
 version: 0.8.1
 ---
 ## CustomContractFunction

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/contract.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/contract.md
@@ -3,8 +3,8 @@ title: contract
 slug: ocean_lib/web3_internal/web3_overrides/contract
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.contract
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/contract.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/contract.py
+version: 0.8.1
 ---
 ## CustomContractFunction
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/http_provider.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/http_provider.md
@@ -3,8 +3,8 @@ title: http_provider
 slug: ocean_lib/web3_internal/web3_overrides/http_provider
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.http_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/http_provider.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/http_provider.py
+version: 0.8.1
 ---
 ## CustomHTTPProvider
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/http_provider.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/http_provider.md
@@ -3,7 +3,7 @@ title: http_provider
 slug: ocean_lib/web3_internal/web3_overrides/http_provider
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.http_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/http_provider.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/http_provider.py
 version: 0.8.1
 ---
 ## CustomHTTPProvider

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/request.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/request.md
@@ -3,8 +3,8 @@ title: request
 slug: ocean_lib/web3_internal/web3_overrides/request
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.request
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/request.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/request.py
+version: 0.8.1
 ---
 Copied from Web3 python library to control the `requests` session parameters.
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/request.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/request.md
@@ -3,7 +3,7 @@ title: request
 slug: ocean_lib/web3_internal/web3_overrides/request
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.request
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/request.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/request.py
 version: 0.8.1
 ---
 Copied from Web3 python library to control the `requests` session parameters.

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/signature.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/signature.md
@@ -3,8 +3,8 @@ title: signature
 slug: ocean_lib/web3_internal/web3_overrides/signature
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.signature
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/signature.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/signature.py
+version: 0.8.1
 ---
 ## SignatureFix
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/signature.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/signature.md
@@ -3,7 +3,7 @@ title: signature
 slug: ocean_lib/web3_internal/web3_overrides/signature
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.signature
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/signature.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/signature.py
 version: 0.8.1
 ---
 ## SignatureFix

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/utils.md
@@ -3,7 +3,7 @@ title: utils
 slug: ocean_lib/web3_internal/web3_overrides/utils
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/utils.py
+source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/utils.py
 version: 0.8.1
 ---
 #### wait\_for\_transaction\_receipt\_and\_block\_confirmations

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/utils.md
@@ -3,8 +3,8 @@ title: utils
 slug: ocean_lib/web3_internal/web3_overrides/utils
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/main/ocean_lib/web3_internal/web3_overrides/utils.py
-version: 0.7.0
+source: https://github.com/oceanprotocol/ocean.py/blob/HEAD/ocean_lib/web3_internal/web3_overrides/utils.py
+version: 0.8.1
 ---
 #### wait\_for\_transaction\_receipt\_and\_block\_confirmations
 


### PR DESCRIPTION
Towards https://github.com/oceanprotocol/ocean.py/issues/497.

Changes proposed in this PR:

- Update ocean.py markdowns to v0.8.1