### PR TITLE
Issue37 update v3 markdowns

### DIFF
--- a/markdowns/ocean-py/README.md
+++ b/markdowns/ocean-py/README.md
@@ -3,11 +3,11 @@ title: README.md
 slug: README.md
 app: ocean.py
 module: README
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/README.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/README.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -46,11 +46,7 @@ ocean.py is part of the [Ocean Protocol](https://www.oceanprotocol.com) toolset.
 This is in beta state and you can expect running into problems. If you run into them, please open up a [new issue](/issues).
 
 - [🏗 Installation](#-installation)
-- [🏄 Quickstart](#-quickstart)
-  - [Simple Flow](#simple-flow)
-  - [Marketplace Flow](#marketplace-flow)
-  - [Compute-to-Data Flow](#compute-to-data-flow)
-  - [Learn more](#learn-more)
+- [🏄 Quickstart](#-quickstart): simple flow, marketplace, compute-to-data, more
 - [🦑 Development](#-development)
 - [🏛 License](#-license)
 
@@ -67,23 +63,12 @@ pip install ocean-lib
 
 ## 🏄 Quickstart
 
-### Simple Flow
+Here are flows to try out, from simple to specific detailed variants.
 
-This stripped-down flow shows the essence of Ocean: simply creating a datatoken.
-
-[Go to simple flow](READMEs/datatokens-flow.md)
-
-### Marketplace flow
-
-In this flow, a data asset is posted for sale in a marketplace, and purchased. It includes metadata and a datatoken pool.
-
-[Go to marketplace flow](READMEs/marketplace-flow.md)
-
-### Compute-to-Data flow
-
-This flow uses Ocean Compute-to-Data (c2d) to compute results from a dataset that never leaves the premises.
-
-[Go to c2d flow](READMEs/c2d-flow.md)
+- **[Simple flow](READMEs/datatokens-flow.md)** - the essence of Ocean - creating a data NFT & datatoken.
+- **[Marketplace flow](READMEs/marketplace-flow.md)** - a data asset is posted for sale in a datatoken pool, then purchased. Includes metadata.
+- **[Fixed rate exchange flow](READMEs/fixed-rate-exchange-flow.md)** - a data asset is posted for sale at fixed rate, then purchased. 
+- **[Compute-to-data flow](READMEs/c2d-flow.md)** - uses C2D to build an AI model a dataset that never leaves the premises.
 
 ### Learn more
 
@@ -99,7 +84,7 @@ This flow uses Ocean Compute-to-Data (c2d) to compute results from a dataset tha
 
 ## 🏛 License
 
-    Copyright ((C)) 2021 Ocean Protocol Foundation
+    Copyright ((C)) 2022 Ocean Protocol Foundation
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/markdowns/ocean-py/READMEs/ALG_ddo.md
+++ b/markdowns/ocean-py/READMEs/ALG_ddo.md
@@ -3,9 +3,13 @@ title: ALG_ddo.md
 slug: READMEs/ALG_ddo.md
 app: ocean.py
 module: READMEs.ALG_ddo
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/ALG_ddo.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/ALG_ddo.md
+version: 0.8.6
 ---
+<!--
+Copyright 2022 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
 (HACK to help debugging. Remove later)
 
 In Python console:

--- a/markdowns/ocean-py/READMEs/DATA_ddo.md
+++ b/markdowns/ocean-py/READMEs/DATA_ddo.md
@@ -3,9 +3,13 @@ title: DATA_ddo.md
 slug: READMEs/DATA_ddo.md
 app: ocean.py
 module: READMEs.DATA_ddo
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/DATA_ddo.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/DATA_ddo.md
+version: 0.8.6
 ---
+<!--
+Copyright 2022 Ocean Protocol Foundation
+SPDX-License-Identifier: Apache-2.0
+-->
 (HACK to help debugging. Remove later)
 
 In Python console:

--- a/markdowns/ocean-py/READMEs/c2d-flow.md
+++ b/markdowns/ocean-py/READMEs/c2d-flow.md
@@ -3,11 +3,11 @@ title: c2d-flow.md
 slug: READMEs/c2d-flow.md
 app: ocean.py
 module: READMEs.c2d-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/c2d-flow.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/c2d-flow.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -268,8 +268,8 @@ You can find more information about how to do this in the [Ocean tutorials](http
 
 In the same Python console:
 ```python
-from ocean_lib.assets import utils
-utils.add_publisher_trusted_algorithm(DATA_ddo, ALG_ddo.did, config.metadata_cache_uri)
+from ocean_lib.assets.trusted_algorithms import add_publisher_trusted_algorithm
+add_publisher_trusted_algorithm(DATA_ddo, ALG_ddo.did, config.metadata_cache_uri)
 ocean.assets.update(DATA_ddo, publisher_wallet=alice_wallet)
 ```
 

--- a/markdowns/ocean-py/READMEs/datatokens-flow.md
+++ b/markdowns/ocean-py/READMEs/datatokens-flow.md
@@ -3,11 +3,11 @@ title: datatokens-flow.md
 slug: READMEs/datatokens-flow.md
 app: ocean.py
 module: READMEs.datatokens-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/datatokens-flow.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/datatokens-flow.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -52,11 +52,7 @@ pip install ocean-lib
 
 #set envvars
 export TEST_PRIVATE_KEY1=0xc594c6e5def4bab63ac29eed19a134c130388f74f019bc74b8f4389df2837a58
-
-#set the address file only for ganache
 export ADDRESS_FILE=~/.ocean/ocean-contracts/artifacts/address.json
-
-#set network URL
 export OCEAN_NETWORK_URL=http://127.0.0.1:8545
 
 #go into python

--- a/markdowns/ocean-py/READMEs/developers.md
+++ b/markdowns/ocean-py/READMEs/developers.md
@@ -3,11 +3,11 @@ title: developers.md
 slug: READMEs/developers.md
 app: ocean.py
 module: READMEs.developers
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/developers.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/developers.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/dispenser-flow.md
+++ b/markdowns/ocean-py/READMEs/dispenser-flow.md
@@ -3,11 +3,11 @@ title: dispenser-flow.md
 slug: READMEs/dispenser-flow.md
 app: ocean.py
 module: READMEs.dispenser-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/dispenser-flow.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/dispenser-flow.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/fixed-rate-exchange-flow.md
+++ b/markdowns/ocean-py/READMEs/fixed-rate-exchange-flow.md
@@ -3,11 +3,11 @@ title: fixed-rate-exchange-flow.md
 slug: READMEs/fixed-rate-exchange-flow.md
 app: ocean.py
 module: READMEs.fixed-rate-exchange-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/fixed-rate-exchange-flow.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/fixed-rate-exchange-flow.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/marketplace-flow.md
+++ b/markdowns/ocean-py/READMEs/marketplace-flow.md
@@ -3,11 +3,11 @@ title: marketplace-flow.md
 slug: READMEs/marketplace-flow.md
 app: ocean.py
 module: READMEs.marketplace-flow
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/marketplace-flow.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/marketplace-flow.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/overview.md
+++ b/markdowns/ocean-py/READMEs/overview.md
@@ -3,11 +3,11 @@ title: overview.md
 slug: READMEs/overview.md
 app: ocean.py
 module: READMEs.overview
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/overview.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/overview.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/parameters.md
+++ b/markdowns/ocean-py/READMEs/parameters.md
@@ -3,11 +3,11 @@ title: parameters.md
 slug: READMEs/parameters.md
 app: ocean.py
 module: READMEs.parameters
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/parameters.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/parameters.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/release-process.md
+++ b/markdowns/ocean-py/READMEs/release-process.md
@@ -3,11 +3,11 @@ title: release-process.md
 slug: READMEs/release-process.md
 app: ocean.py
 module: READMEs.release-process
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/release-process.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/release-process.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/services.md
+++ b/markdowns/ocean-py/READMEs/services.md
@@ -3,11 +3,11 @@ title: services.md
 slug: READMEs/services.md
 app: ocean.py
 module: READMEs.services
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/services.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/services.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/READMEs/wallets.md
+++ b/markdowns/ocean-py/READMEs/wallets.md
@@ -3,11 +3,11 @@ title: wallets.md
 slug: READMEs/wallets.md
 app: ocean.py
 module: READMEs.wallets
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/READMEs/wallets.md
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/READMEs/wallets.md
+version: 0.8.6
 ---
 <!--
-Copyright 2021 Ocean Protocol Foundation
+Copyright 2022 Ocean Protocol Foundation
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/markdowns/ocean-py/ocean_lib/assets/asset.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset.md
@@ -3,8 +3,8 @@ title: asset
 slug: ocean_lib/assets/asset
 app: ocean.py
 module: ocean_lib.assets.asset
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/assets/asset.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/assets/asset.py
+version: 0.8.6
 ---
 ## V3Asset
 

--- a/markdowns/ocean-py/ocean_lib/assets/asset_downloader.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset_downloader.md
@@ -3,8 +3,8 @@ title: asset_downloader
 slug: ocean_lib/assets/asset_downloader
 app: ocean.py
 module: ocean_lib.assets.asset_downloader
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/assets/asset_downloader.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/assets/asset_downloader.py
+version: 0.8.6
 ---
 #### download\_asset\_files
 

--- a/markdowns/ocean-py/ocean_lib/assets/asset_resolver.md
+++ b/markdowns/ocean-py/ocean_lib/assets/asset_resolver.md
@@ -3,8 +3,8 @@ title: asset_resolver
 slug: ocean_lib/assets/asset_resolver
 app: ocean.py
 module: ocean_lib.assets.asset_resolver
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/assets/asset_resolver.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/assets/asset_resolver.py
+version: 0.8.6
 ---
 DID Resolver module.
 

--- a/markdowns/ocean-py/ocean_lib/assets/credentials.md
+++ b/markdowns/ocean-py/ocean_lib/assets/credentials.md
@@ -3,8 +3,8 @@ title: credentials
 slug: ocean_lib/assets/credentials
 app: ocean.py
 module: ocean_lib.assets.credentials
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/assets/credentials.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/assets/credentials.py
+version: 0.8.6
 ---
 ## AddressCredential
 

--- a/markdowns/ocean-py/ocean_lib/assets/did.md
+++ b/markdowns/ocean-py/ocean_lib/assets/did.md
@@ -3,8 +3,8 @@ title: did
 slug: ocean_lib/assets/did
 app: ocean.py
 module: ocean_lib.assets.did
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/assets/did.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/assets/did.py
+version: 0.8.6
 ---
 DID Lib to do DID's and DDO's.
 

--- a/markdowns/ocean-py/ocean_lib/assets/trusted_algorithms.md
+++ b/markdowns/ocean-py/ocean_lib/assets/trusted_algorithms.md
@@ -3,8 +3,8 @@ title: trusted_algorithms
 slug: ocean_lib/assets/trusted_algorithms
 app: ocean.py
 module: ocean_lib.assets.trusted_algorithms
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/assets/trusted_algorithms.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/assets/trusted_algorithms.py
+version: 0.8.6
 ---
 #### generate\_trusted\_algo\_dict
 

--- a/markdowns/ocean-py/ocean_lib/common/agreements/consumable.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/consumable.md
@@ -3,8 +3,8 @@ title: consumable
 slug: ocean_lib/common/agreements/consumable
 app: ocean.py
 module: ocean_lib.common.agreements.consumable
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/common/agreements/consumable.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/common/agreements/consumable.py
+version: 0.8.6
 ---
 ## ConsumableCodes
 

--- a/markdowns/ocean-py/ocean_lib/common/agreements/service_types.md
+++ b/markdowns/ocean-py/ocean_lib/common/agreements/service_types.md
@@ -3,8 +3,8 @@ title: service_types
 slug: ocean_lib/common/agreements/service_types
 app: ocean.py
 module: ocean_lib.common.agreements.service_types
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/common/agreements/service_types.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/common/agreements/service_types.py
+version: 0.8.6
 ---
 Agreements module.
 

--- a/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius.md
+++ b/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius.md
@@ -3,8 +3,8 @@ title: aquarius
 slug: ocean_lib/common/aquarius/aquarius
 app: ocean.py
 module: ocean_lib.common.aquarius.aquarius
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/common/aquarius/aquarius.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/common/aquarius/aquarius.py
+version: 0.8.6
 ---
 Aquarius module.
 Help to communicate with the metadata store.

--- a/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius_provider.md
+++ b/markdowns/ocean-py/ocean_lib/common/aquarius/aquarius_provider.md
@@ -3,8 +3,8 @@ title: aquarius_provider
 slug: ocean_lib/common/aquarius/aquarius_provider
 app: ocean.py
 module: ocean_lib.common.aquarius.aquarius_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/common/aquarius/aquarius_provider.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/common/aquarius/aquarius_provider.py
+version: 0.8.6
 ---
 ## AquariusProvider
 

--- a/markdowns/ocean-py/ocean_lib/common/http_requests/requests_session.md
+++ b/markdowns/ocean-py/ocean_lib/common/http_requests/requests_session.md
@@ -3,8 +3,8 @@ title: requests_session
 slug: ocean_lib/common/http_requests/requests_session
 app: ocean.py
 module: ocean_lib.common.http_requests.requests_session
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/common/http_requests/requests_session.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/common/http_requests/requests_session.py
+version: 0.8.6
 ---
 #### get\_requests\_session
 

--- a/markdowns/ocean-py/ocean_lib/config.md
+++ b/markdowns/ocean-py/ocean_lib/config.md
@@ -3,8 +3,8 @@ title: config
 slug: ocean_lib/config
 app: ocean.py
 module: ocean_lib.config
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/config.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/config.py
+version: 0.8.6
 ---
 ## Config
 

--- a/markdowns/ocean-py/ocean_lib/data_provider/data_service_provider.md
+++ b/markdowns/ocean-py/ocean_lib/data_provider/data_service_provider.md
@@ -3,8 +3,8 @@ title: data_service_provider
 slug: ocean_lib/data_provider/data_service_provider
 app: ocean.py
 module: ocean_lib.data_provider.data_service_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/data_provider/data_service_provider.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/data_provider/data_service_provider.py
+version: 0.8.6
 ---
 Provider module.
 

--- a/markdowns/ocean-py/ocean_lib/example_config.md
+++ b/markdowns/ocean-py/ocean_lib/example_config.md
@@ -3,8 +3,8 @@ title: example_config
 slug: ocean_lib/example_config
 app: ocean.py
 module: ocean_lib.example_config
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/example_config.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/example_config.py
+version: 0.8.6
 ---
 ## ExampleConfig
 

--- a/markdowns/ocean-py/ocean_lib/exceptions.md
+++ b/markdowns/ocean-py/ocean_lib/exceptions.md
@@ -3,8 +3,8 @@ title: exceptions
 slug: ocean_lib/exceptions
 app: ocean.py
 module: ocean_lib.exceptions
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/exceptions.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/exceptions.py
+version: 0.8.6
 ---
 ## OceanEncryptAssetUrlsError
 

--- a/markdowns/ocean-py/ocean_lib/integer.md
+++ b/markdowns/ocean-py/ocean_lib/integer.md
@@ -3,6 +3,6 @@ title: integer
 slug: ocean_lib/integer
 app: ocean.py
 module: ocean_lib.integer
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/integer.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/integer.py
+version: 0.8.6
 ---

--- a/markdowns/ocean-py/ocean_lib/models/algorithm_metadata.md
+++ b/markdowns/ocean-py/ocean_lib/models/algorithm_metadata.md
@@ -3,8 +3,8 @@ title: algorithm_metadata
 slug: ocean_lib/models/algorithm_metadata
 app: ocean.py
 module: ocean_lib.models.algorithm_metadata
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/algorithm_metadata.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/algorithm_metadata.py
+version: 0.8.6
 ---
 ## AlgorithmMetadata
 

--- a/markdowns/ocean-py/ocean_lib/models/balancer_constants.md
+++ b/markdowns/ocean-py/ocean_lib/models/balancer_constants.md
@@ -3,8 +3,8 @@ title: balancer_constants
 slug: ocean_lib/models/balancer_constants
 app: ocean.py
 module: ocean_lib.models.balancer_constants
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/balancer_constants.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/balancer_constants.py
+version: 0.8.6
 ---
 Contains `Balancer` related constants for
 - `GASLIMIT_BFACTORY_NEWBPOOL`

--- a/markdowns/ocean-py/ocean_lib/models/bfactory.md
+++ b/markdowns/ocean-py/ocean_lib/models/bfactory.md
@@ -3,8 +3,8 @@ title: bfactory
 slug: ocean_lib/models/bfactory
 app: ocean.py
 module: ocean_lib.models.bfactory
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/bfactory.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/bfactory.py
+version: 0.8.6
 ---
 ## BFactory
 

--- a/markdowns/ocean-py/ocean_lib/models/bpool.md
+++ b/markdowns/ocean-py/ocean_lib/models/bpool.md
@@ -3,8 +3,8 @@ title: bpool
 slug: ocean_lib/models/bpool
 app: ocean.py
 module: ocean_lib.models.bpool
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/bpool.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/bpool.py
+version: 0.8.6
 ---
 ## BPool
 

--- a/markdowns/ocean-py/ocean_lib/models/btoken.md
+++ b/markdowns/ocean-py/ocean_lib/models/btoken.md
@@ -3,8 +3,8 @@ title: btoken
 slug: ocean_lib/models/btoken
 app: ocean.py
 module: ocean_lib.models.btoken
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/btoken.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/btoken.py
+version: 0.8.6
 ---
 ## BToken
 

--- a/markdowns/ocean-py/ocean_lib/models/compute_input.md
+++ b/markdowns/ocean-py/ocean_lib/models/compute_input.md
@@ -3,8 +3,8 @@ title: compute_input
 slug: ocean_lib/models/compute_input
 app: ocean.py
 module: ocean_lib.models.compute_input
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/compute_input.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/compute_input.py
+version: 0.8.6
 ---
 ## ComputeInput
 

--- a/markdowns/ocean-py/ocean_lib/models/data_token.md
+++ b/markdowns/ocean-py/ocean_lib/models/data_token.md
@@ -3,8 +3,8 @@ title: data_token
 slug: ocean_lib/models/data_token
 app: ocean.py
 module: ocean_lib.models.data_token
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/data_token.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/data_token.py
+version: 0.8.6
 ---
 ## DataToken
 

--- a/markdowns/ocean-py/ocean_lib/models/dispenser.md
+++ b/markdowns/ocean-py/ocean_lib/models/dispenser.md
@@ -3,8 +3,8 @@ title: dispenser
 slug: ocean_lib/models/dispenser
 app: ocean.py
 module: ocean_lib.models.dispenser
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/dispenser.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/dispenser.py
+version: 0.8.6
 ---
 ## DispenserContract
 

--- a/markdowns/ocean-py/ocean_lib/models/dtfactory.md
+++ b/markdowns/ocean-py/ocean_lib/models/dtfactory.md
@@ -3,8 +3,8 @@ title: dtfactory
 slug: ocean_lib/models/dtfactory
 app: ocean.py
 module: ocean_lib.models.dtfactory
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/dtfactory.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/dtfactory.py
+version: 0.8.6
 ---
 ## DTFactory
 

--- a/markdowns/ocean-py/ocean_lib/models/fixed_rate_exchange.md
+++ b/markdowns/ocean-py/ocean_lib/models/fixed_rate_exchange.md
@@ -3,8 +3,8 @@ title: fixed_rate_exchange
 slug: ocean_lib/models/fixed_rate_exchange
 app: ocean.py
 module: ocean_lib.models.fixed_rate_exchange
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/fixed_rate_exchange.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/fixed_rate_exchange.py
+version: 0.8.6
 ---
 ## FixedRateExchange
 

--- a/markdowns/ocean-py/ocean_lib/models/metadata.md
+++ b/markdowns/ocean-py/ocean_lib/models/metadata.md
@@ -3,8 +3,8 @@ title: metadata
 slug: ocean_lib/models/metadata
 app: ocean.py
 module: ocean_lib.models.metadata
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/metadata.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/metadata.py
+version: 0.8.6
 ---
 ## MetadataContract
 

--- a/markdowns/ocean-py/ocean_lib/models/order.md
+++ b/markdowns/ocean-py/ocean_lib/models/order.md
@@ -3,8 +3,8 @@ title: order
 slug: ocean_lib/models/order
 app: ocean.py
 module: ocean_lib.models.order
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/models/order.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/models/order.py
+version: 0.8.6
 ---
 Defines namedtuple `Order`
 

--- a/markdowns/ocean-py/ocean_lib/ocean/env_constants.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/env_constants.md
@@ -3,8 +3,8 @@ title: env_constants
 slug: ocean_lib/ocean/env_constants
 app: ocean.py
 module: ocean_lib.ocean.env_constants
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/env_constants.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/env_constants.py
+version: 0.8.6
 ---
 Defines constants:
 - `ENV_CONFIG_FILE`

--- a/markdowns/ocean-py/ocean_lib/ocean/mint_fake_ocean.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/mint_fake_ocean.md
@@ -3,8 +3,8 @@ title: mint_fake_ocean
 slug: ocean_lib/ocean/mint_fake_ocean
 app: ocean.py
 module: ocean_lib.ocean.mint_fake_ocean
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/mint_fake_ocean.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/mint_fake_ocean.py
+version: 0.8.6
 ---
 #### mint\_fake\_OCEAN
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean.md
@@ -3,8 +3,8 @@ title: ocean
 slug: ocean_lib/ocean/ocean
 app: ocean.py
 module: ocean_lib.ocean.ocean
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/ocean.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/ocean.py
+version: 0.8.6
 ---
 Ocean module.
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_assets.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_assets.md
@@ -3,8 +3,8 @@ title: ocean_assets
 slug: ocean_lib/ocean/ocean_assets
 app: ocean.py
 module: ocean_lib.ocean.ocean_assets
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/ocean_assets.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/ocean_assets.py
+version: 0.8.6
 ---
 Ocean module.
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_compute.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_compute.md
@@ -3,8 +3,8 @@ title: ocean_compute
 slug: ocean_lib/ocean/ocean_compute
 app: ocean.py
 module: ocean_lib.ocean.ocean_compute
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/ocean_compute.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/ocean_compute.py
+version: 0.8.6
 ---
 ## OceanCompute
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_exchange.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_exchange.md
@@ -3,8 +3,8 @@ title: ocean_exchange
 slug: ocean_lib/ocean/ocean_exchange
 app: ocean.py
 module: ocean_lib.ocean.ocean_exchange
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/ocean_exchange.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/ocean_exchange.py
+version: 0.8.6
 ---
 ## OceanExchange
 

--- a/markdowns/ocean-py/ocean_lib/ocean/ocean_pool.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/ocean_pool.md
@@ -3,8 +3,8 @@ title: ocean_pool
 slug: ocean_lib/ocean/ocean_pool
 app: ocean.py
 module: ocean_lib.ocean.ocean_pool
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/ocean_pool.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/ocean_pool.py
+version: 0.8.6
 ---
 ## OceanPool
 

--- a/markdowns/ocean-py/ocean_lib/ocean/util.md
+++ b/markdowns/ocean-py/ocean_lib/ocean/util.md
@@ -3,8 +3,8 @@ title: util
 slug: ocean_lib/ocean/util
 app: ocean.py
 module: ocean_lib.ocean.util
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/ocean/util.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/ocean/util.py
+version: 0.8.6
 ---
 #### get\_web3
 

--- a/markdowns/ocean-py/ocean_lib/utils/utilities.md
+++ b/markdowns/ocean-py/ocean_lib/utils/utilities.md
@@ -3,8 +3,8 @@ title: utilities
 slug: ocean_lib/utils/utilities
 app: ocean.py
 module: ocean_lib.utils.utilities
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/utils/utilities.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/utils/utilities.py
+version: 0.8.6
 ---
 Utilities class
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/constants.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/constants.md
@@ -3,8 +3,8 @@ title: constants
 slug: ocean_lib/web3_internal/constants
 app: ocean.py
 module: ocean_lib.web3_internal.constants
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/constants.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/constants.py
+version: 0.8.6
 ---
 This module holds following default values for Gas price, Gas limit and more.
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/contract_base.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/contract_base.md
@@ -3,8 +3,8 @@ title: contract_base
 slug: ocean_lib/web3_internal/contract_base
 app: ocean.py
 module: ocean_lib.web3_internal.contract_base
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/contract_base.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/contract_base.py
+version: 0.8.6
 ---
 All contracts inherit from `ContractBase` class.
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/contract_utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/contract_utils.md
@@ -3,8 +3,8 @@ title: contract_utils
 slug: ocean_lib/web3_internal/contract_utils
 app: ocean.py
 module: ocean_lib.web3_internal.contract_utils
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/contract_utils.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/contract_utils.py
+version: 0.8.6
 ---
 #### get\_contract\_definition
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/currency.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/currency.md
@@ -3,8 +3,8 @@ title: currency
 slug: ocean_lib/web3_internal/currency
 app: ocean.py
 module: ocean_lib.web3_internal.currency
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/currency.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/currency.py
+version: 0.8.6
 ---
 #### ETHEREUM\_DECIMAL\_CONTEXT
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/event_filter.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/event_filter.md
@@ -3,8 +3,8 @@ title: event_filter
 slug: ocean_lib/web3_internal/event_filter
 app: ocean.py
 module: ocean_lib.web3_internal.event_filter
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/event_filter.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/event_filter.py
+version: 0.8.6
 ---
 ## EventFilter
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/event_listener.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/event_listener.md
@@ -3,8 +3,8 @@ title: event_listener
 slug: ocean_lib/web3_internal/event_listener
 app: ocean.py
 module: ocean_lib.web3_internal.event_listener
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/event_listener.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/event_listener.py
+version: 0.8.6
 ---
 ## EventListener
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/transactions.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/transactions.md
@@ -3,8 +3,8 @@ title: transactions
 slug: ocean_lib/web3_internal/transactions
 app: ocean.py
 module: ocean_lib.web3_internal.transactions
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/transactions.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/transactions.py
+version: 0.8.6
 ---
 #### sign\_hash
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/utils.md
@@ -3,8 +3,8 @@ title: utils
 slug: ocean_lib/web3_internal/utils
 app: ocean.py
 module: ocean_lib.web3_internal.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/utils.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/utils.py
+version: 0.8.6
 ---
 #### generate\_multi\_value\_hash
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/wallet.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/wallet.md
@@ -3,8 +3,8 @@ title: wallet
 slug: ocean_lib/web3_internal/wallet
 app: ocean.py
 module: ocean_lib.web3_internal.wallet
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/wallet.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/wallet.py
+version: 0.8.6
 ---
 ## Wallet
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/contract.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/contract.md
@@ -3,8 +3,8 @@ title: contract
 slug: ocean_lib/web3_internal/web3_overrides/contract
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.contract
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/web3_overrides/contract.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/web3_overrides/contract.py
+version: 0.8.6
 ---
 ## CustomContractFunction
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/http_provider.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/http_provider.md
@@ -3,8 +3,8 @@ title: http_provider
 slug: ocean_lib/web3_internal/web3_overrides/http_provider
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.http_provider
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/web3_overrides/http_provider.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/web3_overrides/http_provider.py
+version: 0.8.6
 ---
 ## CustomHTTPProvider
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/request.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/request.md
@@ -3,8 +3,8 @@ title: request
 slug: ocean_lib/web3_internal/web3_overrides/request
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.request
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/web3_overrides/request.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/web3_overrides/request.py
+version: 0.8.6
 ---
 Copied from Web3 python library to control the `requests` session parameters.
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/signature.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/signature.md
@@ -3,8 +3,8 @@ title: signature
 slug: ocean_lib/web3_internal/web3_overrides/signature
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.signature
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/web3_overrides/signature.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/web3_overrides/signature.py
+version: 0.8.6
 ---
 ## SignatureFix
 

--- a/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/utils.md
+++ b/markdowns/ocean-py/ocean_lib/web3_internal/web3_overrides/utils.md
@@ -3,8 +3,8 @@ title: utils
 slug: ocean_lib/web3_internal/web3_overrides/utils
 app: ocean.py
 module: ocean_lib.web3_internal.web3_overrides.utils
-source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.5-1-g11c361d/ocean_lib/web3_internal/web3_overrides/utils.py
-version: 0.8.5
+source: https://github.com/oceanprotocol/ocean.py/blob/v0.8.6/ocean_lib/web3_internal/web3_overrides/utils.py
+version: 0.8.6
 ---
 #### wait\_for\_transaction\_receipt\_and\_block\_confirmations
 

--- a/markdowns/provider/ocean_provider/config.md
+++ b/markdowns/provider/ocean_provider/config.md
@@ -3,8 +3,8 @@ title: config
 slug: ocean_provider/config
 app: provider
 module: ocean_provider.config
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/config.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/config.py
+version: 0.4.24
 ---
 Config data.
 

--- a/markdowns/provider/ocean_provider/constants.md
+++ b/markdowns/provider/ocean_provider/constants.md
@@ -3,8 +3,8 @@ title: constants
 slug: ocean_provider/constants
 app: provider
 module: ocean_provider.constants
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/constants.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/constants.py
+version: 0.4.24
 ---
 ## ConfigSections
 
@@ -15,7 +15,6 @@ class ConfigSections()
 This class stores values for:
 
 - `RESOURCES`
-- `OSMOSIS`
 
 ## BaseURLs
 

--- a/markdowns/provider/ocean_provider/database.md
+++ b/markdowns/provider/ocean_provider/database.md
@@ -3,8 +3,8 @@ title: database
 slug: ocean_provider/database
 app: provider
 module: ocean_provider.database
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/database.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/database.py
+version: 0.4.24
 ---
 Defines sqlite database related variables.
 

--- a/markdowns/provider/ocean_provider/exceptions.md
+++ b/markdowns/provider/ocean_provider/exceptions.md
@@ -3,8 +3,8 @@ title: exceptions
 slug: ocean_provider/exceptions
 app: provider
 module: ocean_provider.exceptions
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/exceptions.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/exceptions.py
+version: 0.4.24
 ---
 ## InvalidSignatureError
 

--- a/markdowns/provider/ocean_provider/http_provider.md
+++ b/markdowns/provider/ocean_provider/http_provider.md
@@ -3,8 +3,8 @@ title: http_provider
 slug: ocean_provider/http_provider
 app: provider
 module: ocean_provider.http_provider
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/http_provider.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/http_provider.py
+version: 0.4.24
 ---
 ## CustomHTTPProvider
 

--- a/markdowns/provider/ocean_provider/log.md
+++ b/markdowns/provider/ocean_provider/log.md
@@ -3,8 +3,8 @@ title: log
 slug: ocean_provider/log
 app: provider
 module: ocean_provider.log
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/log.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/log.py
+version: 0.4.24
 ---
 #### setup\_logging
 

--- a/markdowns/provider/ocean_provider/models.md
+++ b/markdowns/provider/ocean_provider/models.md
@@ -3,8 +3,8 @@ title: models
 slug: ocean_provider/models
 app: provider
 module: ocean_provider.models
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/models.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/models.py
+version: 0.4.24
 ---
 ## UserNonce
 

--- a/markdowns/provider/ocean_provider/myapp.md
+++ b/markdowns/provider/ocean_provider/myapp.md
@@ -3,8 +3,8 @@ title: myapp
 slug: ocean_provider/myapp
 app: provider
 module: ocean_provider.myapp
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/myapp.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/myapp.py
+version: 0.4.24
 ---
 This module creates an instance of flask `app`, creates `user_nonce` table if not exists, and sets the environment configuration.
 If `PROVIDER_CONFIG_FILE` is not found in environment variables, default `config.ini` file is used.

--- a/markdowns/provider/ocean_provider/requests_session.md
+++ b/markdowns/provider/ocean_provider/requests_session.md
@@ -3,8 +3,8 @@ title: requests_session
 slug: ocean_provider/requests_session
 app: provider
 module: ocean_provider.requests_session
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/requests_session.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/requests_session.py
+version: 0.4.24
 ---
 #### get\_requests\_session
 

--- a/markdowns/provider/ocean_provider/routes/compute.md
+++ b/markdowns/provider/ocean_provider/routes/compute.md
@@ -3,8 +3,8 @@ title: compute
 slug: ocean_provider/routes/compute
 app: provider
 module: ocean_provider.routes.compute
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/routes/compute.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/routes/compute.py
+version: 0.4.24
 ---
 #### computeDelete
 

--- a/markdowns/provider/ocean_provider/routes/consume.md
+++ b/markdowns/provider/ocean_provider/routes/consume.md
@@ -3,8 +3,8 @@ title: consume
 slug: ocean_provider/routes/consume
 app: provider
 module: ocean_provider.routes.consume
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/routes/consume.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/routes/consume.py
+version: 0.4.24
 ---
 #### nonce
 

--- a/markdowns/provider/ocean_provider/run.md
+++ b/markdowns/provider/ocean_provider/run.md
@@ -3,8 +3,8 @@ title: run
 slug: ocean_provider/run
 app: provider
 module: ocean_provider.run
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/run.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/run.py
+version: 0.4.24
 ---
 #### get\_provider\_address
 

--- a/markdowns/provider/ocean_provider/serializers.md
+++ b/markdowns/provider/ocean_provider/serializers.md
@@ -3,8 +3,8 @@ title: serializers
 slug: ocean_provider/serializers
 app: provider
 module: ocean_provider.serializers
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/serializers.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/serializers.py
+version: 0.4.24
 ---
 ## StageAlgoSerializer
 

--- a/markdowns/provider/ocean_provider/user_nonce.md
+++ b/markdowns/provider/ocean_provider/user_nonce.md
@@ -3,8 +3,8 @@ title: user_nonce
 slug: ocean_provider/user_nonce
 app: provider
 module: ocean_provider.user_nonce
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/user_nonce.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/user_nonce.py
+version: 0.4.24
 ---
 #### get\_nonce
 

--- a/markdowns/provider/ocean_provider/utils/accounts.md
+++ b/markdowns/provider/ocean_provider/utils/accounts.md
@@ -3,8 +3,8 @@ title: accounts
 slug: ocean_provider/utils/accounts
 app: provider
 module: ocean_provider.utils.accounts
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/accounts.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/accounts.py
+version: 0.4.24
 ---
 #### verify\_signature
 

--- a/markdowns/provider/ocean_provider/utils/asset.md
+++ b/markdowns/provider/ocean_provider/utils/asset.md
@@ -3,8 +3,8 @@ title: asset
 slug: ocean_provider/utils/asset
 app: provider
 module: ocean_provider.utils.asset
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/asset.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/asset.py
+version: 0.4.24
 ---
 ## Asset
 
@@ -68,7 +68,7 @@ Return encryptedFiles field in the base metadata.
 #### get\_service
 
 ```python
- | def get_service(service_type: str)
+ | def get_service(service_type: str) -> Service
 ```
 
 Return a service using.

--- a/markdowns/provider/ocean_provider/utils/basics.md
+++ b/markdowns/provider/ocean_provider/utils/basics.md
@@ -3,8 +3,8 @@ title: basics
 slug: ocean_provider/utils/basics
 app: provider
 module: ocean_provider.utils.basics
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/basics.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/basics.py
+version: 0.4.24
 ---
 #### get\_config
 
@@ -25,16 +25,6 @@ def get_provider_wallet(web3: Optional[Web3] = None)
 **Returns**:
 
 Wallet instance
-
-#### get\_datatoken\_minter
-
-```python
-def get_datatoken_minter(datatoken_address)
-```
-
-**Returns**:
-
-Eth account address of the Datatoken minter
 
 #### get\_artifacts\_path
 

--- a/markdowns/provider/ocean_provider/utils/consumable.md
+++ b/markdowns/provider/ocean_provider/utils/consumable.md
@@ -3,8 +3,8 @@ title: consumable
 slug: ocean_provider/utils/consumable
 app: provider
 module: ocean_provider.utils.consumable
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/consumable.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/consumable.py
+version: 0.4.24
 ---
 ## ConsumableCodes
 

--- a/markdowns/provider/ocean_provider/utils/credentials.md
+++ b/markdowns/provider/ocean_provider/utils/credentials.md
@@ -3,8 +3,8 @@ title: credentials
 slug: ocean_provider/utils/credentials
 app: provider
 module: ocean_provider.utils.credentials
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/credentials.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/credentials.py
+version: 0.4.24
 ---
 ## AddressCredential
 

--- a/markdowns/provider/ocean_provider/utils/currency.md
+++ b/markdowns/provider/ocean_provider/utils/currency.md
@@ -3,6 +3,6 @@ title: currency
 slug: ocean_provider/utils/currency
 app: provider
 module: ocean_provider.utils.currency
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/currency.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/currency.py
+version: 0.4.24
 ---

--- a/markdowns/provider/ocean_provider/utils/datatoken.md
+++ b/markdowns/provider/ocean_provider/utils/datatoken.md
@@ -3,6 +3,16 @@ title: datatoken
 slug: ocean_provider/utils/datatoken
 app: provider
 module: ocean_provider.utils.datatoken
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/datatoken.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/datatoken.py
+version: 0.4.24
 ---
+#### get\_datatoken\_minter
+
+```python
+def get_datatoken_minter(datatoken_address)
+```
+
+**Returns**:
+
+Eth account address of the Datatoken minter
+

--- a/markdowns/provider/ocean_provider/utils/did.md
+++ b/markdowns/provider/ocean_provider/utils/did.md
@@ -3,8 +3,8 @@ title: did
 slug: ocean_provider/utils/did
 app: provider
 module: ocean_provider.utils.did
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/did.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/did.py
+version: 0.4.24
 ---
 #### did\_to\_id
 

--- a/markdowns/provider/ocean_provider/utils/encryption.md
+++ b/markdowns/provider/ocean_provider/utils/encryption.md
@@ -3,8 +3,8 @@ title: encryption
 slug: ocean_provider/utils/encryption
 app: provider
 module: ocean_provider.utils.encryption
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/encryption.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/encryption.py
+version: 0.4.24
 ---
 #### do\_encrypt
 

--- a/markdowns/provider/ocean_provider/utils/error_responses.md
+++ b/markdowns/provider/ocean_provider/utils/error_responses.md
@@ -3,6 +3,14 @@ title: error_responses
 slug: ocean_provider/utils/error_responses
 app: provider
 module: ocean_provider.utils.error_responses
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/error_responses.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/error_responses.py
+version: 0.4.24
 ---
+#### error\_response
+
+```python
+def error_response(err_str: str, status: int, custom_logger=None)
+```
+
+Logs error and returns an error response.
+

--- a/markdowns/provider/ocean_provider/utils/services.md
+++ b/markdowns/provider/ocean_provider/utils/services.md
@@ -3,8 +3,8 @@ title: services
 slug: ocean_provider/utils/services
 app: provider
 module: ocean_provider.utils.services
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/services.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/services.py
+version: 0.4.24
 ---
 ## Service
 

--- a/markdowns/provider/ocean_provider/utils/url.md
+++ b/markdowns/provider/ocean_provider/utils/url.md
@@ -3,8 +3,8 @@ title: url
 slug: ocean_provider/utils/url
 app: provider
 module: ocean_provider.utils.url
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/url.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/url.py
+version: 0.4.24
 ---
 #### validate\_dns\_records
 

--- a/markdowns/provider/ocean_provider/utils/util.md
+++ b/markdowns/provider/ocean_provider/utils/util.md
@@ -3,8 +3,8 @@ title: util
 slug: ocean_provider/utils/util
 app: provider
 module: ocean_provider.utils.util
-source: https://github.com/oceanprotocol/provider/blob/v0.4.19/ocean_provider/utils/util.py
-version: 0.4.19
+source: https://github.com/oceanprotocol/provider/blob/v0.4.24/ocean_provider/utils/util.py
+version: 0.4.24
 ---
 #### checksum
 


### PR DESCRIPTION
Fixes #37.

Changes proposed in this PR:

- Bump provider from v0.4.19 -> v0.4.24
- Bump ocean.py from v0.8.5 -> v0.8.6